### PR TITLE
Document undocumented keybindings and fix help text errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ VimiCalc (also called WeSpreadSheet) combines the functionality of a traditional
 ## Features
 
 - **Modal editing** — 6 modes inspired by Vim: Normal, Insert, Formula, Command, Visual, and Help
-- **Vim-style navigation** — `h/j/k/l` movement, multipliers (`5j`), and familiar keybindings (`d`, `y`, `p`, `i`, `a`)
+- **Vim-style navigation** — `h/j/k/l` movement, multipliers (`5j`), `g{coords}` go-to (e.g. `gA3`), `Ctrl-O` jump back, and familiar keybindings (`d`, `y`, `p`, `i`, `a`)
 - **RPN formulas** — Reverse Polish Notation formula engine with cell references, ranges (`B2:D3`), and relative coordinates (`kl -3j`)
 - **Matrix operations** — `matMul`, `det`, `tpose`, `sum`, `prod`, `quot`, and more
 - **Math functions** — `sin`, `cos`, `tan`, `asin`, `acos`, `atan`, `ln`, `log10`, `logBase`, `exp`, `sqrt`, `abs`, `PI`
-- **Macros** — Record with `q`, replay with `@`, chain with multipliers (`5@a`)
+- **Macros** — Record with `q`, replay with `@`, chain with multipliers (`5@a`), repeat last command with `.`
 - **Conditional execution** — `<formula{then{else}` syntax for conditional key commands
 - **Cell merging** — Select cells in Visual mode and press `m`
 - **Cell formatting** — Background colors, text colors, and bold via command mode
@@ -24,11 +24,11 @@ VimiCalc (also called WeSpreadSheet) combines the functionality of a traditional
 | Mode | Enter with | Purpose |
 |------|-----------|---------|
 | **Normal** | `ESC` | Navigation and key commands |
-| **Insert** | `i` or `a` | Plain text entry |
+| **Insert** | `i` or `a` | Plain text entry (`ESC` to save, `Shift+ESC` to cancel) |
 | **Formula** | `=` | RPN formula entry (confirm with `Enter`, cancel with `ESC`) |
-| **Visual** | `v` | Multi-cell selection, merging, bulk operations |
+| **Visual** | `v` | Multi-cell selection, merging (`m`), copying (`y`), deleting (`d`), commands (`;`) |
 | **Command** | `:` | Vim-style commands (`:w`, `:q`, `:resCol`, etc.) |
-| **Help** | `:h` or `:help` | Built-in documentation |
+| **Help** | `:h`, `:help`, or `:?` | Built-in documentation |
 
 ## Commands
 
@@ -36,8 +36,8 @@ VimiCalc (also called WeSpreadSheet) combines the functionality of a traditional
 |---------|-------------|
 | `:w [file]` | Save spreadsheet |
 | `:e [file]` | Open spreadsheet |
-| `:q` | Quit |
-| `:wq` | Save and quit |
+| `:q` / `ZQ` | Quit |
+| `:wq` / `ZZ` | Save and quit |
 | `:resCol [pixels]` | Resize column width |
 | `:resRow [pixels]` | Resize row height |
 | `:cellColor [color]` | Set cell background color |

--- a/src/main/java/vimicalc/view/HelpMenu.java
+++ b/src/main/java/vimicalc/view/HelpMenu.java
@@ -10,6 +10,14 @@ import org.jetbrains.annotations.NotNull;
 import static vimicalc.controller.Controller.currMode;
 import static vimicalc.controller.Mode.NORMAL;
 
+/**
+ * An overlay window that displays built-in help text when the user enters
+ * HELP mode (via {@code :h}, {@code :help}, or {@code :?}).
+ *
+ * <p>Supports scrolling with {@code j}/{@code k} keys and dismissal with
+ * {@code ESC}. The text is a static array of lines covering modes,
+ * key commands, macros, formulas, and conditional expressions.</p>
+ */
 public class HelpMenu extends simpleRect {
     private int position;
     private final GraphicsContext gc;
@@ -28,14 +36,16 @@ public class HelpMenu extends simpleRect {
         "\n",
         "\t-INSERT mode is for inserting plain text into a cell. Just type 'a' or 'i' to enter it and 'ESC' to leave",
         "\n",
-        "\t-FORMULA mode is for entering formulas (as in Microsoft Excel). They use Reverse Polish Notation.",
+        "\t-FORMULA mode is for entering formulas (as in Microsoft Excel). Press '=' in NORMAL mode to enter it.",
+        "\t They use Reverse Polish Notation.",
         "\t Examples: 'B2:D3 F7:G9 matMul', '3 5 8 * +', 'kl -3j / 3 mod'",
         "\t That last one used relative coordinates.",
         "\t 'ESC'-ing will just exit this mode and cancel the formula. If you want to save the formula to the cell,",
         "\t you would have to press 'ENTER' instead.",
         "\n",
         "\t-VISUAL mode allows you to select several cells and do things to them.",
-        "\t Things such as merging cells by pressing 'm', or copying them by pressing 'y',",
+        "\t Things such as merging cells by pressing 'm', copying them by pressing 'y', deleting them with 'd',",
+        "\t entering COMMAND mode with ';' to run commands on the selection,",
         "\t and applying formulas while appending the destination coordinate at the end (eg 'A3:B4 det AX8').",
         "\n",
         "\t-COMMAND mode is for entering certain uh commands. Start by typing ':' in NORMAL mode. Examples:",
@@ -46,27 +56,49 @@ public class HelpMenu extends simpleRect {
         "NORMAL mode. They appear at the bottom right of the window as you type.",
         "Here are some more information about them.",
         "\n",
-        "\t-Multipliers: you just type a number before typing the rest of the command, like '5j' or '31@x",
+        "\t-Multipliers: you just type a number before typing the rest of the command, like '5j' or '31@x'",
         "\n",
         "\t-Macros: You type 'q' and then supply a letter as the name of the macro. You can then just do whatever ",
         "\t and everything will be recorded until you press 'q' again. To replay it, just type @[the letter].",
         "\t You could also prefix with a multiplier or stick them inside a conditional KeyCommand.",
         "\n",
-        "\t-Conditional KeyCommands: basically '<[formula]{[then]{[else]}'. You can omit the else part.",
+        "\t-Conditional KeyCommands: basically '<formula{then}{else}'. You can omit the else part.",
         "\t If the formula doesn't evaluate to 0, the KeyCommand in the 'then' part is executed.",
-        "\t Some examples would be helpful: '<C3 2 mod{d5J6l}', '<6 5j2k 3 mod{@a{@b}'",
+        "\t Some examples would be helpful: '<C3 2 mod{d5j6l}', '<6 5j2k 3 mod{@a{@b}'",
         "\n",
-        "\t-The cancel the writing of a KeyCommand, press Ctrl-C",
+        "\t-To cancel the writing of a KeyCommand, press Ctrl-C",
+        "\n",
+        "\t-Go to a specific cell with 'g' followed by the coordinates, like 'gA3'",
+        "\n",
+        "\t-Repeat the last command with '.'",
+        "\n",
+        "\t-'ZZ' saves and quits, 'ZQ' quits without saving",
+        "\n",
+        "\t-'Ctrl-O' jumps back to the previous cursor location",
+        "\n",
+        "In INSERT mode, 'ESC' saves and exits while 'Shift+ESC' cancels without saving.",
         "\n",
         "For more info, there is only the source code and the javadoc for now."
     };
 
+    /**
+     * Creates the help menu overlay.
+     *
+     * @param gc the graphics context for rendering
+     */
     public HelpMenu(GraphicsContext gc) {
         super(30, 30, 740, 480, Color.LIGHTYELLOW);
         this.gc = gc;
         position = 0;
     }
 
+    /**
+     * Handles keyboard input within the help menu.
+     * {@code J} scrolls down, {@code K} scrolls up, {@code ESC} closes the menu
+     * and returns to NORMAL mode.
+     *
+     * @param event the key event to process
+     */
     public void navigate(@NotNull KeyEvent event) {
         switch (event.getCode()) {
             case J -> {
@@ -85,10 +117,16 @@ public class HelpMenu extends simpleRect {
         drawText();
     }
 
+    /**
+     * Returns the current scroll position as a percentage string (e.g. "42%").
+     *
+     * @return the scroll percentage
+     */
     public String percentage() {
         return (int) (100.0 * position / text.length) + "%";
     }
 
+    /** Renders the help text onto the canvas, showing up to 24 lines from the current scroll position. */
     public void drawText() {
         super.draw(gc);
         gc.setFill(Color.BLACK);


### PR DESCRIPTION
Add missing documentation for g{coords}, Ctrl-O, ZZ, ZQ, dot repeat, Shift+ESC cancel, d/; in VISUAL mode, and :? help alias. Fix "The" to "To" typo in HelpMenu.