### PR TITLE
Unmerge the mapped merge-start cell, not a stale reference

### DIFF
--- a/src/main/java/vimicalc/model/Sheet.java
+++ b/src/main/java/vimicalc/model/Sheet.java
@@ -190,10 +190,16 @@ public class Sheet {
      * @param c any cell in the merge group
      */
     public void unmergeCells(@NotNull Cell c) {
-        if (c.isMergeStart())
-            unmergeCells(c, c.getMergeDelimiter());
-        else if (c.getMergeDelimiter() != null)
-            unmergeCells(c.getMergeDelimiter(), c.getMergeDelimiter().getMergeDelimiter());
+        Cell mergeStart = c.isMergeStart() ? c : c.getMergeDelimiter();
+        if (mergeStart == null) return;
+        // Merge pointers can reference an object that addCell has since
+        // replaced in the cell map (e.g. after editing the merged cell's
+        // text), so resolve the merge-start through the map before mutating
+        // it — otherwise only the orphaned copy gets unmerged (issue #29).
+        Cell mapped = simplyFindCell(mergeStart.xCoord(), mergeStart.yCoord());
+        if (mapped.isMergeStart()) mergeStart = mapped;
+        if (mergeStart.getMergeDelimiter() != null)
+            unmergeCells(mergeStart, mergeStart.getMergeDelimiter());
     }
     private void unmergeCells(@NotNull Cell mergeStart, @NotNull Cell mergeEnd) {
         System.out.println("Unmerging cells...");

--- a/src/test/java/vimicalc/controller/MergeInteractionUiTest.java
+++ b/src/test/java/vimicalc/controller/MergeInteractionUiTest.java
@@ -76,6 +76,32 @@ class MergeInteractionUiTest {
             "the command should have applied to the cell it was typed on");
     }
 
+    @Test
+    void unmergeFromInteriorWorksAfterEditingMergedCell(FxRobot robot) {
+        // Merge (2,2)-(5,4), then type text into the merged cell — the INSERT
+        // commit replaces the merge-start object in the cell map while the
+        // interior cells keep referencing the old one (issue #29)
+        robot.type(KeyCode.V, KeyCode.L, KeyCode.L, KeyCode.L, KeyCode.J, KeyCode.J, KeyCode.M);
+        robot.type(KeyCode.I);
+        typeText(robot, "hi");
+        robot.type(KeyCode.ESCAPE);
+        assertTrue(controller.sheet.simplyFindCell(2, 2).isMergeStart());
+
+        // Move below an interior column and unmerge via a VISUAL selection
+        // that touches the interior cell (4,4)
+        robot.type(KeyCode.J, KeyCode.L, KeyCode.L);
+        assertEquals(4, controller.cellSelector.getXCoord());
+        assertEquals(5, controller.cellSelector.getYCoord());
+        robot.type(KeyCode.V, KeyCode.K, KeyCode.M);
+        robot.type(KeyCode.ESCAPE);
+
+        assertFalse(controller.sheet.simplyFindCell(2, 2).isMergeStart(),
+            "the merge-start stored in the cell map must be unmerged");
+        assertTrue(controller.camera.picture.data().stream()
+                .noneMatch(vimicalc.model.Cell::isMergeStart),
+            "no visible cell may still render as a merged block (ghost merge)");
+    }
+
     /** Types text as real key codes; the Controller reads KEY_PRESSED text. */
     private void typeText(FxRobot robot, String s) {
         for (char c : s.toCharArray()) {

--- a/src/test/java/vimicalc/model/SheetTest.java
+++ b/src/test/java/vimicalc/model/SheetTest.java
@@ -268,6 +268,41 @@ class SheetTest {
             assertNull(sheet.simplyFindCell(2, 1).getMergeDelimiter());
             assertNull(sheet.simplyFindCell(1, 2).getMergeDelimiter());
         }
+
+        @Test
+        void unmergeFromInteriorAfterMergeStartWasReplacedInMap() {
+            // Merge (1,1)-(2,2), then replace the merge-start in the cell map
+            // with a copy — as Controller.textInput does when committing text
+            // typed into a merged cell. The interior cells still reference the
+            // old object; unmerging via an interior must still unmerge the
+            // cell actually stored in the map (issue #29).
+            Cell start = new Cell(1, 1, "content");
+            Cell end = new Cell(2, 2);
+            start.setMergeStart(true);
+            start.mergeWith(end);
+            end.mergeWith(start);
+            Cell mid1 = new Cell(2, 1);
+            mid1.mergeWith(start);
+            Cell mid2 = new Cell(1, 2);
+            mid2.mergeWith(start);
+
+            sheet.simplyAddCell(start);
+            sheet.simplyAddCell(end);
+            sheet.simplyAddCell(mid1);
+            sheet.simplyAddCell(mid2);
+
+            sheet.addCell(start.copy());
+
+            sheet.unmergeCells(sheet.findCell(2, 1));
+
+            Cell mappedStart = sheet.simplyFindCell(1, 1);
+            assertFalse(mappedStart.isMergeStart(),
+                "the merge-start stored in the map must be unmerged");
+            assertNull(mappedStart.getMergeDelimiter());
+            assertNull(sheet.simplyFindCell(2, 1).getMergeDelimiter());
+            assertNull(sheet.simplyFindCell(1, 2).getMergeDelimiter());
+            assertNull(sheet.simplyFindCell(2, 2).getMergeDelimiter());
+        }
     }
 
     // ── Dependency re-evaluation ──


### PR DESCRIPTION
Fixes #29.

## Problem

Editing a merged cell's text commits via `sheet.addCell(selectedCell.copy())` (`Controller.textInput`), which **replaces** the merge-start `Cell` object in the cell map — but interior cells keep referencing the old object. `Sheet.unmergeCells` reached the merge start through `interior.getMergeDelimiter()` and cleared `mergeStart`/`mergeDelimiter` on the **orphaned copy**, leaving the map's actual cell merged. The interiors were freed, but `Picture.drawVCells` kept rendering the full merged block forever (the "ghost merge").

## Fix

In the public `unmergeCells(Cell)`, resolve the merge start through the cell map (`simplyFindCell`) before mutating it, falling back to the referenced object if the mapped cell isn't a merge start. Also guards against a null delimiter instead of passing it into the `@NotNull` private overload. The private unmerge loop already operated on map objects and is unchanged.

## Tests

- `SheetTest.MergeTests.unmergeFromInteriorAfterMergeStartWasReplacedInMap` — model-level: reproduces the `addCell(copy())` replacement, unmerges via an interior, asserts the mapped cell is unmerged.
- `MergeInteractionUiTest.unmergeFromInteriorWorksAfterEditingMergedCell` — end-to-end: merges (2,2)-(5,4), types text via real key events, unmerges through a VISUAL selection touching an interior, asserts the mapped merge-start is cleared and no visible cell still renders as a merged block.

Both tests fail without the fix (verified by stashing it: 2/38 failures, exactly these two) and pass with it (full suite: 178/0, run under `xvfb-run`).

Also verified visually by driving the running app headlessly through the exact issue repro: the frame that previously showed the full-width ghost block now renders clear, and after unmerging, the color/text stay confined to the merge-start's own single cell. Adjacent paths probed: NORMAL-mode unmerge after editing, re-merge + unmerge cycle without edits, and `m` on a non-merged cell (clean no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzJGeWZ1D1h9s8cUckoSBk