### PR TITLE
Derive all viewport rendering from a single camera offset

### DIFF
--- a/src/main/java/vimicalc/controller/Controller.java
+++ b/src/main/java/vimicalc/controller/Controller.java
@@ -267,12 +267,6 @@ public class Controller implements Initializable {
                 }
                 currMode = Mode.NORMAL;
                 int prevXC = cellSelector.getXCoord(), prevYC = cellSelector.getYCoord();
-                // Phantom move-left/move-right and move-up/move-down to force a
-                // camera/picture refresh so the command's effects are visible.
-                if (cellSelector.getX() == 0) moveRight();
-                else moveLeft();
-                if (cellSelector.getY() == 0) moveDown();
-                else moveUp();
 
                 String commandError = null;
                 try {
@@ -286,6 +280,9 @@ public class Controller implements Initializable {
                     return;
                 }
 
+                // Relayout at the live camera offset (the command may have
+                // resized columns/rows) and re-derive the cursor from it.
+                camera.picture.metadata().generate(camera.getAbsX(), camera.getAbsY());
                 camera.picture.take(gc, sheet, selectedCoords, camera.getAbsX(), camera.getAbsY());
                 camera.ready();
                 cellSelector.readCell(camera.picture.data());
@@ -778,10 +775,8 @@ public class Controller implements Initializable {
         CANVAS_H = (int) canvas.getHeight();
         sheet = new Sheet();
         sheet.setPositions(new Positions(
-            DEFAULT_CELL_W/2,
-            DEFAULT_CELL_H,
-            CANVAS_W - DEFAULT_CELL_W/2,
-            CANVAS_H - DEFAULT_CELL_H,
+            CANVAS_W - GUTTER_W,
+            CANVAS_H - HEADER_H,
             DEFAULT_CELL_W,
             DEFAULT_CELL_H,
             new HashMap<>(),
@@ -824,13 +819,11 @@ public class Controller implements Initializable {
      */
     void reset() {
         camera = new Camera(
-            DEFAULT_CELL_W/2,
-            DEFAULT_CELL_H,
-            CANVAS_W-DEFAULT_CELL_W/2,
+            GUTTER_W,
+            HEADER_H,
+            CANVAS_W-GUTTER_W,
             CANVAS_H-3*DEFAULT_CELL_H-4,
             DEFAULT_CELL_C,
-            DEFAULT_CELL_W,
-            DEFAULT_CELL_H,
             sheet.getPositions(),
             sheet.getCellsFormatting()
         );
@@ -852,12 +845,9 @@ public class Controller implements Initializable {
         camera.picture.take(gc, sheet, selectedCoords, camera.getAbsX(), camera.getAbsY());
 
         cellSelector = new CellSelector(
-            camera.picture.metadata().getCellAbsXs()[2],
-            camera.picture.metadata().getCellAbsYs()[2],
-            camera.picture.metadata().getCellAbsXs()[2] - camera.picture.metadata().getCellAbsYs()[1],
-            camera.picture.metadata().getCellAbsYs()[2] - camera.picture.metadata().getCellAbsYs()[1],
             new Color(0.0, 0.67, 1, 1),
 //            Color.LIMEGREEN,
+            camera,
             camera.picture.metadata(),
             sheet.getCellsFormatting(),
             () -> currMode
@@ -869,18 +859,20 @@ public class Controller implements Initializable {
         );
         firstCol = new FirstCol(
             0,
-            DEFAULT_CELL_H,
-            DEFAULT_CELL_W/2,
+            HEADER_H,
+            GUTTER_W,
             CANVAS_H-3*DEFAULT_CELL_H-4,
             Color.LIGHTBLUE,
+            camera,
             camera.picture.metadata()
         );
         firstRow = new FirstRow(
-            DEFAULT_CELL_W/2,
+            GUTTER_W,
             0,
-            CANVAS_W-DEFAULT_CELL_W/2,
-            DEFAULT_CELL_H,
+            CANVAS_W-GUTTER_W,
+            HEADER_H,
             Color.LIGHTBLUE,
+            camera,
             camera.picture.metadata()
         );
         infoBar = new InfoBar(

--- a/src/main/java/vimicalc/controller/EditorOperations.java
+++ b/src/main/java/vimicalc/controller/EditorOperations.java
@@ -41,6 +41,35 @@ public class EditorOperations {
     }
 
     /**
+     * Scrolls the camera by exactly the overshoot needed to bring the selected
+     * cell flush into the viewport, then redraws the grid and headers. Both
+     * axes are checked so diagonal displacements (e.g. merge pulls) are
+     * corrected in one step.
+     *
+     * <p>Positions are derived from the cell boundary arrays and the live
+     * camera offset — the shared viewport formula (issue #30) — so repeated
+     * scrolling cannot accumulate drift.</p>
+     */
+    private void scrollCursorIntoView() {
+        int[] xs = ctrl.camera.picture.metadata().getCellAbsXs();
+        int[] ys = ctrl.camera.picture.metadata().getCellAbsYs();
+        int xc = ctrl.cellSelector.getXCoord(), yc = ctrl.cellSelector.getYCoord();
+        int left   = xs[xc]   - ctrl.camera.getAbsX() + GUTTER_W;
+        int right  = xs[xc+1] - ctrl.camera.getAbsX() + GUTTER_W;
+        int top    = ys[yc]   - ctrl.camera.getAbsY() + HEADER_H;
+        int bottom = ys[yc+1] - ctrl.camera.getAbsY() + HEADER_H;
+        int dx = right > ctrl.CANVAS_W ? right - ctrl.CANVAS_W
+               : left < GUTTER_W ? left - GUTTER_W : 0;
+        int dy = bottom > ctrl.statusBar.getY() ? bottom - ctrl.statusBar.getY()
+               : top < HEADER_H ? top - HEADER_H : 0;
+        if (dx == 0 && dy == 0) return;
+        ctrl.camera.scrollBy(dx, dy);
+        ctrl.camera.picture.take(ctrl.gc, ctrl.sheet, ctrl.selectedCoords, ctrl.camera.getAbsX(), ctrl.camera.getAbsY());
+        ctrl.firstRow.draw(ctrl.gc);
+        ctrl.firstCol.draw(ctrl.gc);
+    }
+
+    /**
      * Moves the cell selector one cell to the left. Handles viewport scrolling
      * when the cursor reaches the left edge, and boundary checks.
      */
@@ -54,30 +83,7 @@ public class EditorOperations {
             return;
         }
         cellContentToIBar();
-        if (ctrl.cellSelector.getX() != ctrl.firstCol.getW()) {
-            ctrl.cellSelector.updateX(-ctrl.cellSelector.getW());
-            if (ctrl.cellSelector.getX() < ctrl.firstCol.getW()) {
-                while (ctrl.cellSelector.getX() != ctrl.firstCol.getW()) {
-                    ctrl.cellSelector.updateX(1);
-                    ctrl.camera.updateAbsX(-1);
-                }
-                ctrl.camera.picture.metadata().generate(ctrl.camera.getAbsX(), ctrl.camera.getAbsY());
-                ctrl.camera.picture.take(ctrl.gc, ctrl.sheet, ctrl.selectedCoords, ctrl.camera.getAbsX(), ctrl.camera.getAbsY());
-                ctrl.firstRow.draw(ctrl.gc);
-            }
-        }
-        else {
-            ctrl.camera.updateAbsX(-ctrl.cellSelector.getW());
-            if (ctrl.camera.getAbsX() < ctrl.firstCol.getW()) {
-                ctrl.infoBar.setInfobarTxt("CAN'T GO LEFT");
-                while (ctrl.camera.getAbsX() != ctrl.firstCol.getW())
-                    ctrl.camera.updateAbsX(1);
-            }
-            ctrl.camera.picture.metadata().generate(ctrl.camera.getAbsX(), ctrl.camera.getAbsY());
-            ctrl.camera.picture.take(ctrl.gc, ctrl.sheet, ctrl.selectedCoords, ctrl.camera.getAbsX(), ctrl.camera.getAbsY());
-            ctrl.firstRow.draw(ctrl.gc);
-            ctrl.cellSelector.readCell(ctrl.camera.picture.data());
-        }
+        scrollCursorIntoView();
         ctrl.camera.picture.resend(ctrl.gc, ctrl.camera.getAbsX(), ctrl.camera.getAbsY());
         ctrl.cellSelector.readCell(ctrl.camera.picture.data());
         if (ctrl.currMode != Mode.VISUAL) maybeGoToMergeStart();
@@ -85,37 +91,15 @@ public class EditorOperations {
 
     /** Moves the cell selector one cell down, scrolling the viewport if necessary. */
     public void moveDown() {
-        int prevH;
-        if (!ctrl.cellSelector.getSelectedCell().isMergeStart() || ctrl.currMode == Mode.VISUAL)
-            prevH = ctrl.cellSelector.getH();
-        else {
-            prevH = ctrl.cellSelector.getMergedH();
+        if (ctrl.cellSelector.getSelectedCell().isMergeStart() && ctrl.currMode != Mode.VISUAL)
             ctrl.cellSelector.updateYCoord(
                 ctrl.cellSelector.getSelectedCell().getMergeDelimiter().yCoord() -
                 ctrl.cellSelector.getSelectedCell().yCoord()
             );
-        }
         ctrl.cellSelector.updateYCoord(1);
         ctrl.cellSelector.readCell(ctrl.camera.picture.data());
         cellContentToIBar();
-        if (ctrl.cellSelector.getY() + ctrl.cellSelector.getH() != ctrl.statusBar.getY()) {
-            ctrl.cellSelector.updateY(prevH);
-            if (ctrl.cellSelector.getY() + ctrl.cellSelector.getH() > ctrl.statusBar.getY()) {
-                while (ctrl.cellSelector.getY() + ctrl.cellSelector.getH() != ctrl.statusBar.getY()) {
-                    ctrl.cellSelector.updateY(-1);
-                    ctrl.camera.updateAbsY(1);
-                }
-                ctrl.camera.picture.metadata().generate(ctrl.camera.getAbsX(), ctrl.camera.getAbsY());
-                ctrl.camera.picture.take(ctrl.gc, ctrl.sheet, ctrl.selectedCoords, ctrl.camera.getAbsX(), ctrl.camera.getAbsY());
-                ctrl.firstCol.draw(ctrl.gc);
-            }
-        }
-        else {
-            ctrl.camera.updateAbsY(prevH);
-            ctrl.camera.picture.metadata().generate(ctrl.camera.getAbsX(), ctrl.camera.getAbsY());
-            ctrl.camera.picture.take(ctrl.gc, ctrl.sheet, ctrl.selectedCoords, ctrl.camera.getAbsX(), ctrl.camera.getAbsY());
-            ctrl.firstCol.draw(ctrl.gc);
-        }
+        scrollCursorIntoView();
         ctrl.camera.picture.resend(ctrl.gc, ctrl.camera.getAbsX(), ctrl.camera.getAbsY());
         ctrl.cellSelector.readCell(ctrl.camera.picture.data());
         if (ctrl.currMode != Mode.VISUAL) maybeGoToMergeStart();
@@ -132,29 +116,7 @@ public class EditorOperations {
             return;
         }
         cellContentToIBar();
-        if (ctrl.cellSelector.getY() != DEFAULT_CELL_H) {
-            ctrl.cellSelector.updateY(-ctrl.cellSelector.getH());
-            if (ctrl.cellSelector.getY() < DEFAULT_CELL_H) {
-                while (ctrl.cellSelector.getY() != DEFAULT_CELL_H) {
-                    ctrl.cellSelector.updateY(1);
-                    ctrl.camera.updateAbsY(-1);
-                }
-                ctrl.camera.picture.metadata().generate(ctrl.camera.getAbsX(), ctrl.camera.getAbsY());
-                ctrl.camera.picture.take(ctrl.gc, ctrl.sheet, ctrl.selectedCoords, ctrl.camera.getAbsX(), ctrl.camera.getAbsY());
-                ctrl.firstCol.draw(ctrl.gc);
-            }
-        }
-        else {
-            ctrl.camera.updateAbsY(-ctrl.cellSelector.getH());
-            if (ctrl.camera.getAbsY() < DEFAULT_CELL_H) {
-                ctrl.infoBar.setInfobarTxt("CAN'T GO UP");
-                while (ctrl.camera.getAbsY() != DEFAULT_CELL_H)
-                    ctrl.camera.updateAbsY(1);
-            }
-            ctrl.camera.picture.metadata().generate(ctrl.camera.getAbsX(), ctrl.camera.getAbsY());
-            ctrl.camera.picture.take(ctrl.gc, ctrl.sheet, ctrl.selectedCoords, ctrl.camera.getAbsX(), ctrl.camera.getAbsY());
-            ctrl.firstCol.draw(ctrl.gc);
-        }
+        scrollCursorIntoView();
         ctrl.camera.picture.resend(ctrl.gc, ctrl.camera.getAbsX(), ctrl.camera.getAbsY());
         ctrl.cellSelector.readCell(ctrl.camera.picture.data());
         if (ctrl.currMode != Mode.VISUAL) maybeGoToMergeStart();
@@ -162,36 +124,14 @@ public class EditorOperations {
 
     /** Moves the cell selector one cell to the right, scrolling the viewport if necessary. */
     public void moveRight() {
-        int prevW;
-        if (!ctrl.cellSelector.getSelectedCell().isMergeStart() || ctrl.currMode == Mode.VISUAL)
-            prevW = ctrl.cellSelector.getW();
-        else {
-            prevW = ctrl.cellSelector.getMergedW();
+        if (ctrl.cellSelector.getSelectedCell().isMergeStart() && ctrl.currMode != Mode.VISUAL)
             ctrl.cellSelector.updateXCoord(
                 ctrl.cellSelector.getSelectedCell().getMergeDelimiter().xCoord() -
                 ctrl.cellSelector.getSelectedCell().xCoord()
             );
-        }
         ctrl.cellSelector.updateXCoord(1);
         ctrl.cellSelector.readCell(ctrl.camera.picture.data());
-        if (ctrl.cellSelector.getX() + ctrl.cellSelector.getW() != ctrl.CANVAS_W) {
-            ctrl.cellSelector.updateX(prevW);
-            if (ctrl.cellSelector.getX() + ctrl.cellSelector.getW() > ctrl.CANVAS_W) {
-                while (ctrl.cellSelector.getX() + ctrl.cellSelector.getW() != ctrl.CANVAS_W) {
-                    ctrl.cellSelector.updateX(-1);
-                    ctrl.camera.updateAbsX(1);
-                }
-                ctrl.camera.picture.metadata().generate(ctrl.camera.getAbsX(), ctrl.camera.getAbsY());
-                ctrl.camera.picture.take(ctrl.gc, ctrl.sheet, ctrl.selectedCoords, ctrl.camera.getAbsX(), ctrl.camera.getAbsY());
-                ctrl.firstRow.draw(ctrl.gc);
-            }
-        }
-        else {
-            ctrl.camera.updateAbsX(prevW);
-            ctrl.camera.picture.metadata().generate(ctrl.camera.getAbsX(), ctrl.camera.getAbsY());
-            ctrl.camera.picture.take(ctrl.gc, ctrl.sheet, ctrl.selectedCoords, ctrl.camera.getAbsX(), ctrl.camera.getAbsY());
-            ctrl.firstRow.draw(ctrl.gc);
-        }
+        scrollCursorIntoView();
         ctrl.camera.picture.resend(ctrl.gc, ctrl.camera.getAbsX(), ctrl.camera.getAbsY());
         ctrl.cellSelector.readCell(ctrl.camera.picture.data());
         cellContentToIBar();

--- a/src/main/java/vimicalc/model/Command.java
+++ b/src/main/java/vimicalc/model/Command.java
@@ -89,11 +89,11 @@ public class Command extends Interpretable {
         switch (command[0].getFunc()) {
             case "h", "help", "?" -> commandResult = CommandResult.HELP;
             case "e" -> readFile(sheet, command);
-            case "resCol" -> sheet.getPositions().generate(
+            case "resCol" -> sheet.getPositions().applyOffset(
                 new int[]{xC, (int) command[1].getVal()},
                 true
             );
-            case "resRow" -> sheet.getPositions().generate(
+            case "resRow" -> sheet.getPositions().applyOffset(
                 new int[]{yC, (int) command[1].getVal()},
                 false
             );

--- a/src/main/java/vimicalc/model/Sheet.java
+++ b/src/main/java/vimicalc/model/Sheet.java
@@ -320,7 +320,7 @@ public class Sheet {
         if (cell.xCoord() > positions.getMaxXC() || cell.yCoord() > positions.getMaxYC()) {
             if (cell.xCoord() > positions.getMaxXC()) positions.setMaxXC(cell.xCoord());
             if (cell.yCoord() > positions.getMaxYC()) positions.setMaxYC(cell.yCoord());
-            positions.generate(positions.getCamAbsX(), positions.getCamAbsY());
+            positions.regenerate();
         }
     }
 

--- a/src/main/java/vimicalc/view/Camera.java
+++ b/src/main/java/vimicalc/view/Camera.java
@@ -5,17 +5,23 @@ import javafx.scene.paint.Color;
 import java.util.HashMap;
 import java.util.List;
 
+import static vimicalc.view.Defaults.GUTTER_W;
+import static vimicalc.view.Defaults.HEADER_H;
+
 /**
  * Represents the viewport camera that tracks which portion of the spreadsheet
  * is currently visible on screen.
  *
  * <p>Maintains absolute pixel offsets ({@code absX}, {@code absY}) that determine
- * the scroll position. Owns a {@link Picture} instance responsible for rendering
- * the visible cells.</p>
+ * the scroll position. These offsets are the single source of truth for the
+ * viewport: every renderer (cells, headers, cursor) derives its screen positions
+ * from them. Owns a {@link Picture} instance responsible for rendering the
+ * visible cells.</p>
  */
 public class Camera {
     private int absX;
     private int absY;
+    private final Positions positions;
     /** The picture component responsible for rendering visible cells. */
     public Picture picture;
 
@@ -27,16 +33,15 @@ public class Camera {
      * @param w     the width of the picture area (pixels)
      * @param h     the height of the picture area (pixels)
      * @param c     the background color of the picture area
-     * @param DCW   the default cell width (pixels)
-     * @param DCH   the default cell height (pixels)
      * @param metadata       position metadata for cell layout
      * @param cellsFormatting per-cell formatting overrides
      */
-    public Camera(int x, int y, int w, int h, Color c, int DCW, int DCH, Positions metadata,
+    public Camera(int x, int y, int w, int h, Color c, Positions metadata,
                   HashMap<List<Integer>, Formatting> cellsFormatting) {
-        absX = DCW/2;
-        absY = DCH;
-        picture = new Picture(x, y, w, h, c, DCW, DCH, metadata, cellsFormatting);
+        absX = GUTTER_W;
+        absY = HEADER_H;
+        positions = metadata;
+        picture = new Picture(x, y, w, h, c, metadata, cellsFormatting);
     }
 
     /**
@@ -58,21 +63,21 @@ public class Camera {
     }
 
     /**
-     * Adjusts the horizontal scroll offset by the given delta.
+     * Scrolls the viewport by the given pixel deltas and regenerates the cell
+     * layout metadata. This is the only way to move the camera, so layout can
+     * never be observed out of sync with the scroll offset (issue #30).
      *
-     * @param x_mov the horizontal pixel delta
-     */
-    public void updateAbsX(int x_mov) {
-        absX += x_mov;
-    }
-
-    /**
-     * Adjusts the vertical scroll offset by the given delta.
+     * <p>The offsets are clamped to the home position ({@code GUTTER_W},
+     * {@code HEADER_H}) so the sheet can never scroll past its top-left
+     * corner.</p>
      *
-     * @param y_mov the vertical pixel delta
+     * @param dx the horizontal pixel delta
+     * @param dy the vertical pixel delta
      */
-    public void updateAbsY(int y_mov) {
-        absY += y_mov;
+    public void scrollBy(int dx, int dy) {
+        absX = Math.max(GUTTER_W, absX + dx);
+        absY = Math.max(HEADER_H, absY + dy);
+        positions.generate(absX, absY);
     }
 
     /** Marks the picture as ready for a lightweight re-render (no full snapshot). */

--- a/src/main/java/vimicalc/view/CellSelector.java
+++ b/src/main/java/vimicalc/view/CellSelector.java
@@ -14,39 +14,43 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.function.Supplier;
 
+import static vimicalc.view.Defaults.GUTTER_W;
+import static vimicalc.view.Defaults.HEADER_H;
+
 /**
  * The cursor / selection highlight that indicates which cell is currently
  * active in the spreadsheet.
  *
- * <p>Tracks both the logical cell coordinates ({@code xCoord}, {@code yCoord})
- * and the pixel position on the canvas. Handles merged cells by expanding
- * the highlight to cover the full merged area. Also supports rendering
- * text as it is typed in INSERT mode.</p>
+ * <p>Tracks the logical cell coordinates ({@code xCoord}, {@code yCoord});
+ * the pixel position and size are always derived from the grid layout and
+ * the live camera offset (see {@link #syncToGrid()}), never accumulated.
+ * Handles merged cells by expanding the highlight to cover the full merged
+ * area. Also supports rendering text as it is typed in INSERT mode.</p>
  */
 public class CellSelector extends simpleRect {
 
     private int xCoord, yCoord, mergedW, mergedH;
     private Cell selectedCell;
+    private final Camera camera;
     private final Positions picPositions;
     private final Supplier<Mode> modeSupplier;
     private final HashMap<List<Integer>, Formatting> cellsFormatting;
 
     /**
-     * Creates a cell selector at the given pixel position.
+     * Creates a cell selector; its pixel position is derived from the grid
+     * layout, so {@code picPositions} must already be generated.
      *
-     * @param x               the x pixel position
-     * @param y               the y pixel position
-     * @param w               the width in pixels
-     * @param h               the height in pixels
      * @param c               the highlight color
+     * @param camera          the viewport camera the pixel position derives from
      * @param picPositions    the position metadata for cell layout
      * @param cellsFormatting per-cell formatting overrides, used to style the
      *                        selected cell's text like its rendered form
      * @param modeSupplier    supplies the current editing mode
      */
-    public CellSelector(int x, int y, int w, int h, Color c, Positions picPositions,
+    public CellSelector(Color c, Camera camera, Positions picPositions,
                         HashMap<List<Integer>, Formatting> cellsFormatting, Supplier<Mode> modeSupplier) {
-        super(x, y, w, h, c);
+        super(0, 0, 0, 0, c);
+        this.camera = camera;
         this.picPositions = picPositions;
         this.cellsFormatting = cellsFormatting;
         this.modeSupplier = modeSupplier;
@@ -55,6 +59,7 @@ public class CellSelector extends simpleRect {
         xCoord = 2;
         yCoord = 2;
         selectedCell = new Cell(xCoord, yCoord);
+        syncToGrid();
     }
 
     /**
@@ -163,24 +168,6 @@ public class CellSelector extends simpleRect {
     }
 
     /**
-     * Adjusts the pixel x-position by the given delta.
-     *
-     * @param x_mov the horizontal pixel delta
-     */
-    public void updateX(int x_mov) {
-        x += x_mov;
-    }
-
-    /**
-     * Adjusts the pixel y-position by the given delta.
-     *
-     * @param y_mov the vertical pixel delta
-     */
-    public void updateY(int y_mov) {
-        y += y_mov;
-    }
-
-    /**
      * Adjusts the logical column coordinate by the given delta.
      *
      * @param xCoord_mov the column delta
@@ -218,16 +205,24 @@ public class CellSelector extends simpleRect {
                     mergedH = picPositions.getCellAbsYs()[mergeEnd.yCoord()+1] -
                         picPositions.getCellAbsYs()[yCoord];
                 }
-                setDimensions();
+                syncToGrid();
                 return;
             }
         }
         selectedCell = new Cell(xCoord, yCoord);
-        setDimensions();
+        syncToGrid();
     }
 
-    private void setDimensions() {
-        w = picPositions.getCellAbsXs()[xCoord+1] - picPositions.getCellAbsXs()[xCoord];
-        h = picPositions.getCellAbsYs()[yCoord+1] - picPositions.getCellAbsYs()[yCoord];
+    /**
+     * Derives the pixel position and size from the grid layout and the live
+     * camera offset — the same formula the cell grid and headers use, so the
+     * highlight can never drift away from its cell (issue #30).
+     */
+    private void syncToGrid() {
+        int[] xs = picPositions.getCellAbsXs(), ys = picPositions.getCellAbsYs();
+        w = xs[xCoord+1] - xs[xCoord];
+        h = ys[yCoord+1] - ys[yCoord];
+        x = xs[xCoord] - camera.getAbsX() + GUTTER_W;
+        y = ys[yCoord] - camera.getAbsY() + HEADER_H;
     }
 }

--- a/src/main/java/vimicalc/view/Defaults.java
+++ b/src/main/java/vimicalc/view/Defaults.java
@@ -17,6 +17,10 @@ public final class Defaults {
     public static final int DEFAULT_CELL_H = 24;
     /** Default cell width in pixels (4x the height; halved for the first-column gutter in layout). */
     public static final int DEFAULT_CELL_W = DEFAULT_CELL_H * 4;
+    /** Width in pixels of the row-number gutter ({@link FirstCol}) on the left edge. */
+    public static final int GUTTER_W = DEFAULT_CELL_W / 2;
+    /** Height in pixels of the column-letter header row ({@link FirstRow}) on the top edge. */
+    public static final int HEADER_H = DEFAULT_CELL_H;
     /** Default font size in points (matches the JavaFX canvas default font). */
     public static final int DEFAULT_FONT_SIZE = 13;
     /** Default cell background color. */

--- a/src/main/java/vimicalc/view/FirstCol.java
+++ b/src/main/java/vimicalc/view/FirstCol.java
@@ -13,6 +13,7 @@ import org.jetbrains.annotations.NotNull;
  * using the layout information from {@link Positions}.</p>
  */
 public class FirstCol extends simpleRect {
+    Camera camera;
     Positions picPositions;
 
     /**
@@ -23,10 +24,12 @@ public class FirstCol extends simpleRect {
      * @param w            the width in pixels
      * @param h            the height in pixels
      * @param c            the background color
+     * @param camera       the viewport camera the label positions derive from
      * @param picPositions the position metadata for cell layout
      */
-    public FirstCol(int x, int y, int w, int h, Color c, Positions picPositions) {
+    public FirstCol(int x, int y, int w, int h, Color c, Camera camera, Positions picPositions) {
         super(x, y, w, h, c);
+        this.camera = camera;
         this.picPositions = picPositions;
     }
 
@@ -41,7 +44,7 @@ public class FirstCol extends simpleRect {
             cellHeight = picPositions.getCellAbsYs()[yC+1] - picPositions.getCellAbsYs()[yC];
             gc.fillText(""+yC
                 , (float) w/2
-                , picPositions.getCellAbsYs()[yC] - picPositions.getCamAbsY() + y + (float) cellHeight/2
+                , picPositions.getCellAbsYs()[yC] - camera.getAbsY() + y + (float) cellHeight/2
                 , w);
         }
     }

--- a/src/main/java/vimicalc/view/FirstRow.java
+++ b/src/main/java/vimicalc/view/FirstRow.java
@@ -14,6 +14,7 @@ import static vimicalc.utils.Conversions.toAlpha;
  * column, using the layout information from {@link Positions}.</p>
  */
 public class FirstRow extends simpleRect {
+    Camera camera;
     Positions picPositions;
 
     /**
@@ -24,10 +25,12 @@ public class FirstRow extends simpleRect {
      * @param w            the width in pixels
      * @param h            the height in pixels
      * @param c            the background color
+     * @param camera       the viewport camera the label positions derive from
      * @param picPositions the position metadata for cell layout
      */
-    public FirstRow(int x, int y, int w, int h, Color c, Positions picPositions) {
+    public FirstRow(int x, int y, int w, int h, Color c, Camera camera, Positions picPositions) {
         super(x, y, w, h, c);
+        this.camera = camera;
         this.picPositions = picPositions;
     }
 
@@ -40,7 +43,7 @@ public class FirstRow extends simpleRect {
         for (int xC = picPositions.getFirstXC(); xC <= picPositions.getLastXC(); xC++) {
             cellWidth = picPositions.getCellAbsXs()[xC+1] - picPositions.getCellAbsXs()[xC];
             gc.fillText(toAlpha(xC-1)
-                , picPositions.getCellAbsXs()[xC] - picPositions.getCamAbsX() + x + (float) cellWidth/2
+                , picPositions.getCellAbsXs()[xC] - camera.getAbsX() + x + (float) cellWidth/2
                 , (float) h/2
                 , cellWidth);
         }

--- a/src/main/java/vimicalc/view/Picture.java
+++ b/src/main/java/vimicalc/view/Picture.java
@@ -13,6 +13,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static vimicalc.view.Defaults.GUTTER_W;
+import static vimicalc.view.Defaults.HEADER_H;
+
 /**
  * The main spreadsheet grid renderer, responsible for drawing all visible cells
  * onto the canvas.
@@ -22,10 +25,6 @@ import java.util.Map;
  * and visual selection highlighting.</p>
  */
 public class Picture extends simpleRect {
-    /** Default cell width in pixels. */
-    private final int DCW;
-    /** Default cell height in pixels. */
-    private final int DCH;
     private ArrayList<Cell> visibleCells;
     private boolean isntReady;
     private final Positions metadata;
@@ -39,16 +38,12 @@ public class Picture extends simpleRect {
      * @param w               the width in pixels
      * @param h               the height in pixels
      * @param c               the background color
-     * @param DCW             the default cell width
-     * @param DCH             the default cell height
      * @param metadata        the position metadata
      * @param cellsFormatting per-cell formatting overrides
      */
-    public Picture(int x, int y, int w, int h, Color c, int DCW, int DCH, Positions metadata,
+    public Picture(int x, int y, int w, int h, Color c, Positions metadata,
                    HashMap<List<Integer>, Formatting> cellsFormatting) {
         super(x, y, w, h, c);
-        this.DCW = DCW;
-        this.DCH = DCH;
         this.metadata = metadata;
         this.cellsFormatting = cellsFormatting;
     }
@@ -124,8 +119,8 @@ public class Picture extends simpleRect {
         gc.setFill(new Color(0,0.67,1,1));
         selectedCoords.forEach(c ->
             gc.fillRect(
-                metadata.getCellAbsXs()[c[0]] - absX + (float) DCW/2,
-                metadata.getCellAbsYs()[c[1]] - absY + DCH,
+                metadata.getCellAbsXs()[c[0]] - absX + GUTTER_W,
+                metadata.getCellAbsYs()[c[1]] - absY + HEADER_H,
                 metadata.getCellAbsXs()[c[0]+1] - metadata.getCellAbsXs()[c[0]],
                 metadata.getCellAbsYs()[c[1]+1] - metadata.getCellAbsYs()[c[1]]
             )
@@ -170,8 +165,8 @@ public class Picture extends simpleRect {
                 System.out.println(cellsFormatting.get(List.of(c.xCoord(), c.yCoord())));
                 cellsFormatting.get(List.of(c.xCoord(), c.yCoord())).renderCell(
                     gc,
-                    (int) (metadata.getCellAbsXs()[c.xCoord()] - absX + (float)DCW/2),
-                    metadata.getCellAbsYs()[c.yCoord()] - absY + DCH,
+                    metadata.getCellAbsXs()[c.xCoord()] - absX + GUTTER_W,
+                    metadata.getCellAbsYs()[c.yCoord()] - absY + HEADER_H,
                     cellWidth,
                     cellHeight,
                     c.txt()
@@ -179,8 +174,8 @@ public class Picture extends simpleRect {
             } catch (Exception ignored) {
                 gc.fillText(
                     c.txt(),
-                   metadata.getCellAbsXs()[c.xCoord()] - absX + (float) DCW / 2 + (float) cellWidth / 2,
-                   metadata.getCellAbsYs()[c.yCoord()] - absY + DCH + (float) cellHeight / 2,
+                   metadata.getCellAbsXs()[c.xCoord()] - absX + GUTTER_W + (float) cellWidth / 2,
+                   metadata.getCellAbsYs()[c.yCoord()] - absY + HEADER_H + (float) cellHeight / 2,
                     cellWidth
                 );
             }
@@ -198,8 +193,8 @@ public class Picture extends simpleRect {
                         ignore = true;
                 if (!ignore) entry.getValue().renderCell(
                     gc,
-                    (int) (metadata.getCellAbsXs()[formattingXC] - absX + (float) DCW/2),
-                    metadata.getCellAbsYs()[formattingYC] - absY + DCH,
+                    metadata.getCellAbsXs()[formattingXC] - absX + GUTTER_W,
+                    metadata.getCellAbsYs()[formattingYC] - absY + HEADER_H,
                     metadata.getCellAbsXs()[formattingXC+1] - metadata.getCellAbsXs()[formattingXC],
                     metadata.getCellAbsYs()[formattingYC+1] - metadata.getCellAbsYs()[formattingYC],
                     ""

--- a/src/main/java/vimicalc/view/Positions.java
+++ b/src/main/java/vimicalc/view/Positions.java
@@ -15,7 +15,13 @@ import java.util.HashMap;
  * <p>Regenerated every time the camera moves or column/row sizes change.</p>
  */
 public class Positions {
-    private int camAbsX, camAbsY, firstXC, lastXC, firstYC, lastYC, maxXC, maxYC;
+    /**
+     * The viewport edges passed to the last {@link #generate(int, int)} call.
+     * Only used by {@link #regenerate()} to re-run layout at the same spot;
+     * never a substitute for the live camera offset (see issue #30).
+     */
+    private int lastXInnerEdge, lastYInnerEdge;
+    private int firstXC, lastXC, firstYC, lastYC, maxXC, maxYC;
     private final int picW, picH, DCW, DCH;
     private HashMap<Integer, Integer> xOffsets;
     private HashMap<Integer, Integer> yOffsets;
@@ -24,8 +30,6 @@ public class Positions {
     /**
      * Creates a new position layout manager.
      *
-     * @param camAbsX  the initial camera horizontal offset
-     * @param camAbsY  the initial camera vertical offset
      * @param picW     the picture area width in pixels
      * @param picH     the picture area height in pixels
      * @param DCW      the default cell width in pixels
@@ -33,10 +37,8 @@ public class Positions {
      * @param xOffsets per-column pixel offsets from default width
      * @param yOffsets per-row pixel offsets from default height
      */
-    public Positions(int camAbsX, int camAbsY, int picW, int picH, int DCW, int DCH,
+    public Positions(int picW, int picH, int DCW, int DCH,
                      HashMap<Integer, Integer> xOffsets, HashMap<Integer, Integer> yOffsets) {
-        this.camAbsX = camAbsX;
-        this.camAbsY = camAbsY;
         this.xOffsets = xOffsets;
         this.yOffsets = yOffsets;
         this.picW = picW;
@@ -131,8 +133,18 @@ public class Positions {
         System.out.println("\t" + Arrays.toString(cellAbsYs));
         System.out.println('}');
 
-        camAbsX = xInnerEdge;
-        camAbsY = yInnerEdge;
+        lastXInnerEdge = xInnerEdge;
+        lastYInnerEdge = yInnerEdge;
+    }
+
+    /**
+     * Re-runs {@link #generate(int, int)} at the last-generated viewport edges.
+     * Used by callers without access to the camera (the model layer); safe
+     * because {@link Camera#scrollBy(int, int)} regenerates on every camera
+     * move, so the last edges always match the live offset.
+     */
+    public void regenerate() {
+        generate(lastXInnerEdge, lastYInnerEdge);
     }
 
     /**
@@ -142,12 +154,12 @@ public class Positions {
      *                  its pixel offset from the default size
      * @param isXAxis   {@code true} to resize a column, {@code false} for a row
      */
-    public void generate(int[] newOffset, boolean isXAxis) {
+    public void applyOffset(int[] newOffset, boolean isXAxis) {
         if (isXAxis)
             xOffsets.put(newOffset[0], newOffset[1]);
         else
             yOffsets.put(newOffset[0], newOffset[1]);
-        generate(camAbsX, camAbsY);
+        regenerate();
     }
 
     /** @return the first visible column coordinate */
@@ -178,16 +190,6 @@ public class Positions {
     /** @return the array of absolute y pixel positions for row boundaries */
     public int[] getCellAbsYs() {
         return cellAbsYs;
-    }
-
-    /** @return the camera horizontal offset */
-    public int getCamAbsX() {
-        return camAbsX;
-    }
-
-    /** @return the camera vertical offset */
-    public int getCamAbsY() {
-        return camAbsY;
     }
 
     /** @return the per-column pixel offset map */

--- a/src/test/java/vimicalc/controller/ViewportSyncUiTest.java
+++ b/src/test/java/vimicalc/controller/ViewportSyncUiTest.java
@@ -1,0 +1,175 @@
+package vimicalc.controller;
+
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Parent;
+import javafx.scene.Scene;
+import javafx.scene.input.KeyCode;
+import javafx.stage.Stage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.api.FxRobot;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+import vimicalc.Main;
+import vimicalc.view.Positions;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static vimicalc.view.Defaults.*;
+
+/**
+ * Regression tests for issue #30: the cell grid, headers, and cursor used to
+ * track the scroll position through three independent pixel accountings
+ * (Camera, Positions, CellSelector) that drifted apart after scrolling or
+ * {@code :resCol}/{@code :resRow}. All viewport consumers now derive screen
+ * positions from the live camera offset via the shared formula
+ * {@code cellAbs - camera.abs + GUTTER_W/HEADER_H}; these tests pin that
+ * invariant through the interaction paths that used to desync.
+ */
+@ExtendWith(ApplicationExtension.class)
+class ViewportSyncUiTest {
+
+    private Controller controller;
+
+    @Start
+    void start(Stage stage) throws Exception {
+        FXMLLoader loader = new FXMLLoader(Main.class.getResource("GUI.fxml"));
+        Parent root = loader.load();
+        controller = loader.getController();
+        Scene scene = new Scene(root, 900, 600);
+        scene.setOnKeyPressed(controller::onKeyPressed);
+        stage.setScene(scene);
+        stage.show();
+    }
+
+    @Test
+    void cursorStaysAlignedThroughScrollSequences(FxRobot robot) {
+        for (int i = 0; i < 12; i++) robot.type(KeyCode.L);
+        assertCursorGridAligned();
+        for (int i = 0; i < 25; i++) robot.type(KeyCode.J);
+        assertCursorGridAligned();
+        for (int i = 0; i < 6; i++) robot.type(KeyCode.H);
+        assertCursorGridAligned();
+        for (int i = 0; i < 10; i++) robot.type(KeyCode.K);
+        assertCursorGridAligned();
+        assertTrue(controller.camera.getAbsX() >= GUTTER_W,
+            "camera must never scroll left of the sheet origin");
+        assertTrue(controller.camera.getAbsY() >= HEADER_H,
+            "camera must never scroll above the sheet origin");
+    }
+
+    @Test
+    void scrollOutAndBackReturnsCameraHome(FxRobot robot) {
+        for (int i = 0; i < 15; i++) robot.type(KeyCode.L);
+        for (int i = 0; i < 20; i++) robot.type(KeyCode.H);
+        assertEquals(1, controller.cellSelector.getXCoord());
+        assertEquals(GUTTER_W, controller.camera.getAbsX(),
+            "scrolling back to column 1 must land the camera exactly home (no residual drift)");
+        assertCursorGridAligned();
+
+        for (int i = 0; i < 25; i++) robot.type(KeyCode.J);
+        for (int i = 0; i < 30; i++) robot.type(KeyCode.K);
+        assertEquals(1, controller.cellSelector.getYCoord());
+        assertEquals(HEADER_H, controller.camera.getAbsY(),
+            "scrolling back to row 1 must land the camera exactly home (no residual drift)");
+        assertCursorGridAligned();
+    }
+
+    @Test
+    void resColAndResRowKeepCursorAligned(FxRobot robot) {
+        // Cursor starts at (2,2); move to column 3 and widen it by 31px —
+        // the relayout used to shift the grid under a stale header/cursor
+        robot.type(KeyCode.L);
+        int prevAbsX = controller.camera.getAbsX(), prevAbsY = controller.camera.getAbsY();
+        robot.type(KeyCode.SEMICOLON);
+        typeText(robot, "resCol 31");
+        robot.type(KeyCode.ENTER);
+
+        Positions pos = controller.camera.picture.metadata();
+        assertEquals(DEFAULT_CELL_W + 31, pos.getCellAbsXs()[4] - pos.getCellAbsXs()[3],
+            "column 3 must be widened by the resCol offset");
+        assertEquals(prevAbsX, controller.camera.getAbsX(), "resCol must not move the camera");
+        assertEquals(prevAbsY, controller.camera.getAbsY(), "resCol must not move the camera");
+        assertCursorGridAligned();
+
+        robot.type(KeyCode.SEMICOLON);
+        typeText(robot, "resRow 13");
+        robot.type(KeyCode.ENTER);
+        assertEquals(DEFAULT_CELL_H + 13, pos.getCellAbsYs()[3] - pos.getCellAbsYs()[2],
+            "row 2 must be taller by the resRow offset");
+        assertCursorGridAligned();
+
+        // Scroll across the resized column/row: the exact-overshoot scroll must
+        // keep the alignment invariant through non-default cell sizes
+        for (int i = 0; i < 10; i++) robot.type(KeyCode.L);
+        assertCursorGridAligned();
+        for (int i = 0; i < 25; i++) robot.type(KeyCode.J);
+        assertCursorGridAligned();
+    }
+
+    @Test
+    void colonCommandDoesNotMoveCameraOrCursor(FxRobot robot) {
+        robot.type(KeyCode.L, KeyCode.J);
+        int prevAbsX = controller.camera.getAbsX(), prevAbsY = controller.camera.getAbsY();
+        int prevXC = controller.cellSelector.getXCoord(), prevYC = controller.cellSelector.getYCoord();
+
+        // The ENTER handler used to issue phantom moves that nudged the camera
+        // without regenerating the layout
+        robot.type(KeyCode.SEMICOLON);
+        typeText(robot, "cellColor red");
+        robot.type(KeyCode.ENTER);
+
+        assertEquals(prevAbsX, controller.camera.getAbsX(), "colon command must not move the camera");
+        assertEquals(prevAbsY, controller.camera.getAbsY(), "colon command must not move the camera");
+        assertEquals(prevXC, controller.cellSelector.getXCoord());
+        assertEquals(prevYC, controller.cellSelector.getYCoord());
+        assertCursorGridAligned();
+    }
+
+    @Test
+    void cursorSitsFlushAtEdgesAfterScroll(FxRobot robot) {
+        // 852px of drawable width / 96px columns: the 8th L from B2 scrolls
+        for (int i = 0; i < 8; i++) robot.type(KeyCode.L);
+        assertTrue(controller.camera.getAbsX() > GUTTER_W, "rightward scroll expected");
+        assertEquals(controller.CANVAS_W,
+            controller.cellSelector.getX() + controller.cellSelector.getW(),
+            "after a scroll the cursor cell must sit flush against the right edge");
+        assertCursorGridAligned();
+
+        for (int i = 0; i < 21; i++) robot.type(KeyCode.J);
+        assertTrue(controller.camera.getAbsY() > HEADER_H, "downward scroll expected");
+        assertEquals(controller.statusBar.getY(),
+            controller.cellSelector.getY() + controller.cellSelector.getH(),
+            "after a scroll the cursor cell must sit flush against the bottom edge");
+        assertCursorGridAligned();
+    }
+
+    /**
+     * The issue #30 invariant: the cursor's pixel rectangle equals the shared
+     * viewport formula applied to its logical cell — the same arithmetic the
+     * grid and headers render with.
+     */
+    private void assertCursorGridAligned() {
+        Positions pos = controller.camera.picture.metadata();
+        int xc = controller.cellSelector.getXCoord(), yc = controller.cellSelector.getYCoord();
+        assertEquals(pos.getCellAbsXs()[xc] - controller.camera.getAbsX() + GUTTER_W,
+            controller.cellSelector.getX(), "cursor X must derive from the live camera offset");
+        assertEquals(pos.getCellAbsYs()[yc] - controller.camera.getAbsY() + HEADER_H,
+            controller.cellSelector.getY(), "cursor Y must derive from the live camera offset");
+        assertEquals(pos.getCellAbsXs()[xc+1] - pos.getCellAbsXs()[xc],
+            controller.cellSelector.getW(), "cursor width must match the cell's boundary span");
+        assertEquals(pos.getCellAbsYs()[yc+1] - pos.getCellAbsYs()[yc],
+            controller.cellSelector.getH(), "cursor height must match the cell's boundary span");
+    }
+
+    /** Types text as real key codes; the Controller reads KEY_PRESSED text. */
+    private void typeText(FxRobot robot, String s) {
+        for (char c : s.toCharArray()) {
+            if (c == ' ') robot.type(KeyCode.SPACE);
+            else if (Character.isUpperCase(c))
+                robot.press(KeyCode.SHIFT)
+                     .type(KeyCode.getKeyCode(String.valueOf(c)))
+                     .release(KeyCode.SHIFT);
+            else robot.type(KeyCode.getKeyCode(String.valueOf(Character.toUpperCase(c))));
+        }
+    }
+}

--- a/src/test/java/vimicalc/model/FormulaTest.java
+++ b/src/test/java/vimicalc/model/FormulaTest.java
@@ -17,7 +17,7 @@ class FormulaTest {
     void setUp() {
         sheet = new Sheet();
         Positions positions = new Positions(
-            0, 0, 2000, 2000, 100, 30,
+            2000, 2000, 100, 30,
             new HashMap<>(), new HashMap<>()
         );
         positions.generate(0, 0);

--- a/src/test/java/vimicalc/model/SheetTest.java
+++ b/src/test/java/vimicalc/model/SheetTest.java
@@ -21,7 +21,7 @@ class SheetTest {
     void setUp() {
         sheet = new Sheet();
         Positions positions = new Positions(
-            0, 0, 2000, 2000, 100, 30,
+            2000, 2000, 100, 30,
             new HashMap<>(), new HashMap<>()
         );
         positions.generate(0, 0);
@@ -340,7 +340,7 @@ class SheetTest {
         void setUpLoadSheet() {
             loadSheet = new Sheet();
             Positions p = new Positions(
-                0, 0, 2000, 2000, 100, 30,
+                2000, 2000, 100, 30,
                 new HashMap<>(), new HashMap<>()
             );
             p.generate(0, 0);

--- a/src/test/java/vimicalc/view/PositionsTest.java
+++ b/src/test/java/vimicalc/view/PositionsTest.java
@@ -1,0 +1,77 @@
+package vimicalc.view;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for {@link Positions} layout generation, in particular the
+ * camera-less re-layout entry points ({@link Positions#regenerate()} and
+ * {@link Positions#applyOffset(int[], boolean)}) that the model layer and
+ * {@code :resCol}/{@code :resRow} rely on (issue #30).
+ */
+class PositionsTest {
+
+    private Positions positions;
+
+    @BeforeEach
+    void setUp() {
+        positions = new Positions(852, 552, 96, 24, new HashMap<>(), new HashMap<>());
+        positions.generate(48, 24);
+    }
+
+    @Test
+    void regenerateReproducesTheLastGeneratedLayout() {
+        int[] xs = positions.getCellAbsXs().clone(), ys = positions.getCellAbsYs().clone();
+        int firstXC = positions.getFirstXC(), lastXC = positions.getLastXC();
+        int firstYC = positions.getFirstYC(), lastYC = positions.getLastYC();
+
+        positions.regenerate();
+
+        assertArrayEquals(xs, positions.getCellAbsXs());
+        assertArrayEquals(ys, positions.getCellAbsYs());
+        assertEquals(firstXC, positions.getFirstXC());
+        assertEquals(lastXC, positions.getLastXC());
+        assertEquals(firstYC, positions.getFirstYC());
+        assertEquals(lastYC, positions.getLastYC());
+    }
+
+    @Test
+    void regenerateTracksTheEdgesOfTheLastGenerate() {
+        positions.generate(144, 72);
+        int firstXC = positions.getFirstXC(), firstYC = positions.getFirstYC();
+
+        positions.regenerate();
+
+        assertEquals(firstXC, positions.getFirstXC(),
+            "regenerate must re-run layout at the most recent viewport edges");
+        assertEquals(firstYC, positions.getFirstYC());
+    }
+
+    @Test
+    void applyOffsetWidensOnlyTheTargetColumn() {
+        int firstXC = positions.getFirstXC();
+
+        positions.applyOffset(new int[]{3, 31}, true);
+
+        int[] xs = positions.getCellAbsXs();
+        assertEquals(96, xs[3] - xs[2], "columns before the target keep the default width");
+        assertEquals(96 + 31, xs[4] - xs[3], "the target column gains exactly the offset");
+        assertEquals(96, xs[5] - xs[4], "columns after the target keep the default width");
+        assertEquals(firstXC, positions.getFirstXC(),
+            "resizing must relayout at the previously generated edges");
+    }
+
+    @Test
+    void applyOffsetGrowsOnlyTheTargetRow() {
+        positions.applyOffset(new int[]{2, 13}, false);
+
+        int[] ys = positions.getCellAbsYs();
+        assertEquals(24, ys[2] - ys[1], "rows before the target keep the default height");
+        assertEquals(24 + 13, ys[3] - ys[2], "the target row gains exactly the offset");
+        assertEquals(24, ys[4] - ys[3], "rows after the target keep the default height");
+    }
+}


### PR DESCRIPTION
Closes #30.

## Problem

Three independent pixel accountings tracked the scroll position and were never reconciled:

1. **`Camera.absX/absY`** — a `+=` delta accumulator, used by `Picture` for cell rendering.
2. **`Positions.camAbsX/camAbsY`** — a snapshot of the args to the *last* `generate()` call, used by `FirstRow`/`FirstCol` to place header labels. The `:resCol`/`:resRow` path regenerated from this stale cache.
3. **`CellSelector.x/y`** — the cursor's own pixel integration, driven by hand-tuned deltas and 1px `while`-loops in the movers.

After scrolling, `:resCol`, or the COMMAND-mode phantom moves, these drifted apart — measured as the grid sliding 12px under the row-number gutter and cell fills drawn 31px right of their header columns (see issue for pixel-verified frames).

## Fix

`Camera.absX/absY` is now the single source of truth:

- **`Camera.scrollBy(dx, dy)`** is the only mutation path and regenerates the layout metadata atomically, so "camera moved but layout didn't" is impossible by construction. `updateAbsX/updateAbsY` are gone.
- **Headers** read the live camera offset; `Positions`' cached edges are now private, reachable only through `regenerate()`/`applyOffset()` (the camera-less entry points for `Sheet.simplyAddCell` and `:resCol`/`:resRow`).
- **The cursor derives its rectangle** from the cell boundary arrays and the live camera via the shared formula `cellAbs − camera.abs + GUTTER_W/HEADER_H` (`CellSelector.syncToGrid()`, run on every `readCell`) instead of accumulating deltas.
- **The movers'** four 1px scroll loops and `prevW/prevH` bookkeeping collapse into one exact-overshoot `scrollCursorIntoView()`.
- **The colon-command handler's phantom moves** are replaced with an explicit relayout at the live offset, so `:resCol` relayouts can no longer key headers off a stale offset.
- The gutter/header dimensions get named constants (`GUTTER_W`, `HEADER_H`) instead of hand-written `DEFAULT_CELL_W/2`/`DEFAULT_CELL_H` expressions in ten places, and the cursor-width seed in `Controller.reset` that mixed X and Y boundaries is gone with the pixel-seed constructor.

## Behavior notes

- **At-edge moves across resized columns/rows** now scroll by the exact overshoot instead of the departing cell's size — identical outcome for default sizes, correct (previously drifting) for resized ones.
- **Kept as-is**: pixel-flush scrolling means the first visible column/row can still sit partially under the gutter/header after edge-scrolls. Snapping edge-scrolls to cell boundaries is a possible follow-up, deliberately out of scope here.

## Testing

- New `ViewportSyncUiTest` (TestFX, 5 tests): cursor/grid/camera alignment invariant through scroll sequences, scroll-out-and-back returns the camera *exactly* home (no residual accumulator drift), `:resCol 31`/`:resRow 13` keep the cursor aligned (the 31px regression), colon commands don't move the camera (phantom-move regression), cursor renders flush at right/bottom edges after scrolls.
- New `PositionsTest` (pure JVM, 4 tests): `regenerate()` idempotence and edge-tracking, `applyOffset` resizes exactly the target column/row.
- Full suite green under `xvfb-run ./gradlew test`, including the existing merge-interaction UI tests.
- Screenshot-verified against the real app under Xvfb with a throwaway probe (not committed): pixel-scanned the rendered canvas for the selector and a color-filled cell at formula-predicted positions after scrolls and `:resCol` — flush edges and exact 31px shift confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)