### PR TITLE
Land go-to on merge start when targeting a merge interior

### DIFF
--- a/src/main/java/vimicalc/controller/EditorOperations.java
+++ b/src/main/java/vimicalc/controller/EditorOperations.java
@@ -227,17 +227,29 @@ public class EditorOperations {
      * Navigates the cell selector to the given coordinates by issuing
      * repeated move commands.
      *
+     * <p>If the target lies inside a merged range (including the non-start
+     * delimiter corner), it is remapped to the merge-start cell first — the
+     * same convention as hjkl via {@link #maybeGoToMergeStart()}. Without
+     * that remap, step-wise movement cannot settle on a merge interior:
+     * each entry into the range is pulled back to the start, and the loop
+     * exits beside the merge (issue #31).</p>
+     *
      * <p>Both axes are re-checked after every single step: a move (or the
      * merge pull in {@link #maybeGoToMergeStart()}) can displace the axis
      * that was already corrected, so running one axis to completion before
      * the other lands on the wrong cell next to merged ranges. An iteration
-     * cap guards against unreachable targets (e.g. a merge interior, whose
-     * pull would otherwise oscillate forever).</p>
+     * cap guards against pathological non-convergence (e.g. sheet-boundary
+     * blocks or residual merge skip/pull ping-pong en route).</p>
      *
      * @param xCoord the target column (one-based)
      * @param yCoord the target row (one-based)
      */
     public void goTo(int xCoord, int yCoord) {
+        // Land on merge start when the target is a merge interior (issue #31).
+        Cell resolved = ctrl.sheet.findCell(xCoord, yCoord);
+        xCoord = resolved.xCoord();
+        yCoord = resolved.yCoord();
+
         int guard = 3 * (Math.abs(xCoord - ctrl.cellSelector.getXCoord()) +
                          Math.abs(yCoord - ctrl.cellSelector.getYCoord())) + 32;
         boolean xFirst = true;

--- a/src/test/java/vimicalc/controller/MergeInteractionUiTest.java
+++ b/src/test/java/vimicalc/controller/MergeInteractionUiTest.java
@@ -102,6 +102,83 @@ class MergeInteractionUiTest {
             "no visible cell may still render as a merged block (ghost merge)");
     }
 
+    @Test
+    void goToMergeInteriorLandsOnMergeStart(FxRobot robot) {
+        // Build merge B2:E4 = (2,2)-(5,4) on the model (avoids TestFX key
+        // delivery, which is unreliable on rootless Xwayland), then approach
+        // from below the range and go-to an interior cell (issue #31).
+        robot.interact(() -> {
+            mergeRange(2, 2, 5, 4);
+            refreshView();
+            controller.editorOps.goTo(2, 5); // below merge start
+            assertEquals(2, controller.cellSelector.getXCoord());
+            assertEquals(5, controller.cellSelector.getYCoord());
+
+            controller.editorOps.goTo(3, 3); // interior C3
+
+            assertEquals(2, controller.cellSelector.getXCoord(),
+                "go-to merge interior must land on merge-start column");
+            assertEquals(2, controller.cellSelector.getYCoord(),
+                "go-to merge interior must land on merge-start row");
+            assertTrue(controller.cellSelector.getSelectedCell().isMergeStart(),
+                "selected cell must be the merge start");
+        });
+    }
+
+    @Test
+    void goToMergeDelimiterFromBelowRightLandsOnMergeStart(FxRobot robot) {
+        // Same merge, approach from below-right, target the non-start
+        // delimiter corner E4 — different approach direction, same landing.
+        robot.interact(() -> {
+            mergeRange(2, 2, 5, 4);
+            refreshView();
+            controller.editorOps.goTo(6, 5); // below-right of merge
+            assertEquals(6, controller.cellSelector.getXCoord());
+            assertEquals(5, controller.cellSelector.getYCoord());
+
+            controller.editorOps.goTo(5, 4); // merge-end delimiter
+
+            assertEquals(2, controller.cellSelector.getXCoord(),
+                "go-to merge delimiter must land on merge-start column");
+            assertEquals(2, controller.cellSelector.getYCoord(),
+                "go-to merge delimiter must land on merge-start row");
+            assertTrue(controller.cellSelector.getSelectedCell().isMergeStart());
+        });
+    }
+
+    /**
+     * Creates a rectangular merge on the sheet matching VISUAL-mode {@code m}
+     * wiring (start at top-left, end at bottom-right, interiors point at start).
+     */
+    private void mergeRange(int minXC, int minYC, int maxXC, int maxYC) {
+        vimicalc.model.Cell mergeStart = controller.sheet.findCell(minXC, minYC);
+        vimicalc.model.Cell mergeEnd = controller.sheet.findCell(maxXC, maxYC);
+        if (mergeStart.isEmpty()) controller.sheet.addCell(mergeStart);
+        if (mergeEnd.isEmpty()) controller.sheet.addCell(mergeEnd);
+        else mergeEnd = new vimicalc.model.Cell(mergeEnd.xCoord(), mergeEnd.yCoord());
+        mergeStart.setMergeStart(true);
+        mergeStart.mergeWith(mergeEnd);
+        mergeEnd.mergeWith(mergeStart);
+        for (int i = minXC; i <= maxXC; i++) {
+            for (int j = minYC; j <= maxYC; j++) {
+                if (i == minXC && j == minYC) continue;
+                if (i == maxXC && j == maxYC) continue;
+                vimicalc.model.Cell c = new vimicalc.model.Cell(i, j);
+                c.mergeWith(mergeStart);
+                controller.sheet.addCell(c);
+            }
+        }
+        // ensure end is in the map (may have been replaced when non-empty)
+        controller.sheet.addCell(mergeEnd);
+    }
+
+    private void refreshView() {
+        controller.camera.picture.take(
+            controller.gc, controller.sheet, controller.selectedCoords,
+            controller.camera.getAbsX(), controller.camera.getAbsY());
+        controller.cellSelector.readCell(controller.camera.picture.data());
+    }
+
     /** Types text as real key codes; the Controller reads KEY_PRESSED text. */
     private void typeText(FxRobot robot, String s) {
         for (char c : s.toCharArray()) {


### PR DESCRIPTION
## Summary
- Fix `EditorOperations.goTo` so a target inside a merged range (or the non-start delimiter corner) remaps to the merge start before step navigation, matching hjkl / `maybeGoToMergeStart` (closes #31).
- Without that remap, the move loop oscillates and exits beside the merge, so later commands (`m`, `:cellColor`, macros) silently hit the wrong cell.
- Add regression tests in `MergeInteractionUiTest` for interior and delimiter-corner targets from different approach directions.

## Test plan
- [x] `MergeInteractionUiTest.goToMerge*` (model-backed setup + `editorOps.goTo`)
- [x] model / utils / view / `KeyCommandParsingTest`
- [ ] Optional manual: merge a block → `g` to an interior ref → cursor on top-left; colon command / `m` apply there