### PR TITLE
Fix off-by-one merge-delimiter column label in Cell.toString

### DIFF
--- a/src/main/java/vimicalc/model/Cell.java
+++ b/src/main/java/vimicalc/model/Cell.java
@@ -5,8 +5,8 @@ import org.jetbrains.annotations.NotNull;
 import java.text.DecimalFormat;
 import java.util.Objects;
 
+import static vimicalc.utils.Conversions.coordsIntsToStr;
 import static vimicalc.utils.Conversions.isNumber;
-import static vimicalc.utils.Conversions.toAlpha;
 
 /**
  * Represents a single cell in the spreadsheet.
@@ -177,7 +177,7 @@ public class Cell {
     public String toString() {
         String mergeDelimiterCoords;
         try {
-            mergeDelimiterCoords = toAlpha(mergeDelimiter.xCoord) + mergeDelimiter.yCoord;
+            mergeDelimiterCoords = coordsIntsToStr(mergeDelimiter.xCoord, mergeDelimiter.yCoord);
         } catch (Exception ignored) {
             mergeDelimiterCoords = "null";
         }

--- a/src/test/java/vimicalc/model/CellTest.java
+++ b/src/test/java/vimicalc/model/CellTest.java
@@ -249,4 +249,33 @@ class CellTest {
             assertNull(c.getMergeDelimiter());
         }
     }
+
+    @Nested
+    class ToStringTests {
+
+        @Test
+        void mergeStartPrintsDelimiterLabel() {
+            // Merge J6:X6 — start (10,6) points at delimiter X6 (24,6)
+            Cell start = new Cell(10, 6);
+            start.setMergeStart(true);
+            start.mergeWith(new Cell(24, 6));
+            assertTrue(start.toString().contains("mergeDelimiter=X6"),
+                       "expected delimiter X6, got: " + start);
+        }
+
+        @Test
+        void mergeInteriorPrintsStartLabel() {
+            // Interior (11,6) of merge J6:X6 points back at the start J6 (10,6)
+            Cell interior = new Cell(11, 6);
+            interior.mergeWith(new Cell(10, 6));
+            assertTrue(interior.toString().contains("mergeDelimiter=J6"),
+                       "expected delimiter J6, got: " + interior);
+        }
+
+        @Test
+        void unmergedCellPrintsNullDelimiter() {
+            Cell c = new Cell(1, 1);
+            assertTrue(c.toString().contains("mergeDelimiter=null"));
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- `Cell.toString` passed the one-based `xCoord` of the merge delimiter directly to the zero-based `toAlpha`, so every delimiter label printed one column to the right (a J6:X6 merge logged its delimiter as `Y6`, interiors as `K6`).
- Replace the hand-rolled conversion with the existing `Conversions.coordsIntsToStr`, which already applies the `-1` shift (same helper pattern as `FirstRow.draw`).
- Add `CellTest.ToStringTests` covering the merge-start label, the interior back-reference label, and the unmerged `null` case.

Closes #33

## Test plan
- [x] `./gradlew test` — model / utils / view / `KeyCommandParsingTest`
- [x] Full suite incl. TestFX UI tests under Xvfb on `kubuntu` — 193 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
