### PR TITLE
Make dot repeat replay only editing commands, like Vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ VimiCalc (also called WeSpreadSheet) combines the functionality of a traditional
 - **RPN formulas** — Reverse Polish Notation formula engine with cell references, ranges (`B2:D3`), and relative coordinates (`kl -3j`)
 - **Matrix operations** — `matMul`, `det`, `tpose`, `sum`, `prod`, `quot`, and more
 - **Math functions** — `sin`, `cos`, `tan`, `asin`, `acos`, `atan`, `ln`, `log10`, `logBase`, `exp`, `sqrt`, `abs`, `PI`
-- **Macros** — Record with `q`, replay with `@`, chain with multipliers (`5@a`), repeat last command with `.`
+- **Macros** — Record with `q`, replay with `@`, chain with multipliers (`5@a`), repeat the last editing command (`dd`, `yy`, `pp`, …) with `.`
 - **Conditional execution** — `<formula{then{else}` syntax for conditional key commands
 - **Cell merging** — Select cells in Visual mode and press `m`
 - **Cell formatting** — Background colors, text colors, and bold via command mode

--- a/src/main/java/vimicalc/controller/KeyCommand.java
+++ b/src/main/java/vimicalc/controller/KeyCommand.java
@@ -22,7 +22,7 @@ import static vimicalc.utils.Conversions.isNumber;
  *   <li><b>Navigation:</b> g{coords} (go-to), Ctrl-O (jump back)</li>
  *   <li><b>Editing:</b> i/a (enter INSERT), = (enter FORMULA), v (enter VISUAL)</li>
  *   <li><b>Undo/redo:</b> u (undo), r (redo)</li>
- *   <li><b>Macros:</b> q{letter} (record), @{letter} (play), . (repeat last)</li>
+ *   <li><b>Macros:</b> q{letter} (record), @{letter} (play), . (repeat last edit)</li>
  *   <li><b>Conditionals:</b> &lt;formula{then}{else} (conditional execution)</li>
  *   <li><b>Cell ref:</b> ${coords}{movement} (use cell value as multiplier; last char must be a movement key)</li>
  *   <li><b>Range operations:</b> {func}{multiplier}{dir} (e.g. "d5j" to delete 5 cells down)</li>
@@ -35,9 +35,13 @@ public class KeyCommand {
     private final HashSet<Character> Ffuncs = new HashSet<>(Set.of('d', 'p'));
     /** "Movement functions" — the four directional keys used in Vim-style navigation. */
     public static final HashSet<Character> Mfuncs = new HashSet<>(Set.of('h', 'j', 'k', 'l'));
+    /** "Editing functions" — commands that modify the sheet (dd, yy/yd, pp, m) and are
+     *  therefore replayable by the {@code .} command. */
+    public static final HashSet<Character> EditFuncs = new HashSet<>(Set.of('d', 'y', 'p', 'm'));
     /** The current key-command expression being built. */
     private String expr;
-    /** The previous completed expression, replayed by the {@code .} command. */
+    /** The last completed editing expression, replayed by the {@code .} command.
+     *  Movement and other non-editing expressions do not overwrite it. */
     private String prevExpr;
     /** The macro currently being recorded. */
     protected LinkedList<KeyEvent> currMacro;
@@ -158,6 +162,20 @@ public class KeyCommand {
             i++;
         int multiplier = (i == startIndex) ? 1 : Integer.parseInt(expr.substring(startIndex, i));
         return new Prefix(i, multiplier);
+    }
+
+    /**
+     * Returns whether a completed expression is an editing command that the
+     * {@code .} command should replay. Movement and other non-editing
+     * expressions leave the dot register untouched, matching Vim's
+     * "repeat the last change" semantics.
+     *
+     * @param expr the completed key-command expression
+     * @return {@code true} if the expression should become the {@code .} target
+     */
+    public boolean updatesDotRegister(@NotNull String expr) {
+        Prefix prefix = parsePrefix(0, expr);
+        return prefix.funcIndex() < expr.length() && EditFuncs.contains(expr.charAt(prefix.funcIndex()));
     }
 
     /**
@@ -448,7 +466,7 @@ public class KeyCommand {
         }
 
         if (evaluationFinished) {
-            prevExpr = expr;
+            if (updatesDotRegister(expr)) prevExpr = expr;
             this.expr = "";
         }
     }

--- a/src/test/java/vimicalc/controller/KeyCommandManualTests.md
+++ b/src/test/java/vimicalc/controller/KeyCommandManualTests.md
@@ -139,14 +139,20 @@ Legend:
 3. Press `q` — info bar shows "Macro recorded"
 4. Press `@` `a` — the cell below should now contain "macro", cursor moves down
 
-### 7.2 Repeat last command (.)
-Note: `.` replays the last KeyCommand expression, including movement keys.
-Since there's no mouse navigation yet, any movement between `.` presses
-will overwrite the previous expression. See issue #24.
+### 7.2 Repeat last editing command (.)
+Note: `.` replays the last *editing* expression (`dd`, `yy`, `yd`, `pp`, `m`,
+macro replays). Movement keys, undo/redo, and mode switches do not overwrite
+it — Vim-like behavior, per issue #24.
 
+1. Enter "one" into A1 and "two" into A2
+2. At A1, press `d` `d` — A1 is deleted
+3. Press `j` — moves to A2
+4. Press `.` — A2 is deleted (replays `dd`, not `j`)
+
+### 7.3 Dot ignores movement-only presses
 1. At A1, press `3` `j` — moves to A4
-2. Press `.` — moves 3 more rows down to A7 (replays `3j`)
-3. Press `.` — moves to A10
+2. Press `.` — nothing moves (movement never enters the dot register;
+   if an edit was made earlier in the session, that edit repeats instead)
 
 ---
 

--- a/src/test/java/vimicalc/controller/KeyCommandParsingTest.java
+++ b/src/test/java/vimicalc/controller/KeyCommandParsingTest.java
@@ -145,4 +145,41 @@ class KeyCommandParsingTest {
         assertFalse(KeyCommand.Mfuncs.contains('p'));
         assertFalse(KeyCommand.Mfuncs.contains('x'));
     }
+
+    // --- Dot-register updates (issue #24) ---
+
+    @Test
+    void editingCommandsUpdateDotRegister() {
+        assertTrue(kc.updatesDotRegister("dd"));
+        assertTrue(kc.updatesDotRegister("yy"));
+        assertTrue(kc.updatesDotRegister("yd"));
+        assertTrue(kc.updatesDotRegister("pp"));
+        assertTrue(kc.updatesDotRegister("m"));
+    }
+
+    @Test
+    void multipliedEditingCommandsUpdateDotRegister() {
+        assertTrue(kc.updatesDotRegister("3dd"));
+        assertTrue(kc.updatesDotRegister("12pp"));
+        assertTrue(kc.updatesDotRegister("d5j")); // range delete
+    }
+
+    @Test
+    void movementDoesNotUpdateDotRegister() {
+        assertFalse(kc.updatesDotRegister("h"));
+        assertFalse(kc.updatesDotRegister("j"));
+        assertFalse(kc.updatesDotRegister("k"));
+        assertFalse(kc.updatesDotRegister("l"));
+        assertFalse(kc.updatesDotRegister("5j"));
+        assertFalse(kc.updatesDotRegister("12h"));
+    }
+
+    @Test
+    void nonEditingCommandsDoNotUpdateDotRegister() {
+        assertFalse(kc.updatesDotRegister("u"));  // undo
+        assertFalse(kc.updatesDotRegister("r"));  // redo
+        assertFalse(kc.updatesDotRegister("v"));  // enter VISUAL
+        assertFalse(kc.updatesDotRegister("gA3")); // go-to
+        assertFalse(kc.updatesDotRegister(""));
+    }
 }


### PR DESCRIPTION
## Summary
- `.` used to replay the last completed KeyCommand expression of any kind, so navigating after an edit (`dd` → `j`) overwrote the dot register and `.` repeated the movement instead of the deletion.
- Add an `EditFuncs` whitelist (`d`, `y`, `p`, `m`) alongside the existing `Ffuncs`/`Mfuncs` sets and a pure `updatesDotRegister(expr)` helper built on `parsePrefix`; the `prevExpr` update in `evaluate` is now gated on it. Movement (`hjkl`, go-to), undo/redo, and mode switches never touch the register; multiplied forms (`3dd`) and range ops (`d5j`) still do. Macro replay (`@x`) keeps its explicit `prevExpr` update, so `.` after a macro reruns the macro.
- `a`/`i` are deliberately excluded: expression replay can't reproduce the typed text, so repeating "enter INSERT mode" would be useless.
- Unit tests for `updatesDotRegister` in `KeyCommandParsingTest`; updated the manual test plan (§7.2/§7.3), README, and Javadoc to describe the new semantics.

Closes #24

## Test plan
- [x] `./gradlew test` — model / utils / view / `KeyCommandParsingTest` incl. new dot-register cases
- [x] Full suite incl. TestFX UI tests under Xvfb on `kubuntu` — 193 tests, 0 failures
- [ ] Manual (`KeyCommandManualTests.md` §7.2): `dd` on a filled cell → `j` → `.` deletes the next cell; `3j` → `.` does not move

🤖 Generated with [Claude Code](https://claude.com/claude-code)
