### PR TITLE
Add view zoom (Ctrl+= / Ctrl+- / Ctrl+0, :zoom) and demo spreadsheets

### DIFF
--- a/demos/budget.json
+++ b/demos/budget.json
@@ -1,0 +1,309 @@
+{
+  "version": 1,
+  "cells": [
+    {
+      "x": 3,
+      "y": 2
+    },
+    {
+      "x": 2,
+      "y": 2,
+      "txt": "Monthly Budget",
+      "mergeStart": true,
+      "mergeEndX": 3,
+      "mergeEndY": 2
+    },
+    {
+      "x": 3,
+      "y": 3,
+      "txt": "Amount"
+    },
+    {
+      "x": 2,
+      "y": 3,
+      "txt": "Item"
+    },
+    {
+      "x": 3,
+      "y": 4,
+      "txt": "850"
+    },
+    {
+      "x": 2,
+      "y": 4,
+      "txt": "Rent"
+    },
+    {
+      "x": 3,
+      "y": 5,
+      "txt": "355"
+    },
+    {
+      "x": 2,
+      "y": 5,
+      "txt": "Groceries"
+    },
+    {
+      "x": 3,
+      "y": 6,
+      "txt": "90"
+    },
+    {
+      "x": 2,
+      "y": 6,
+      "txt": "Transport"
+    },
+    {
+      "x": 3,
+      "y": 7,
+      "txt": "140"
+    },
+    {
+      "x": 2,
+      "y": 7,
+      "txt": "Utilities"
+    },
+    {
+      "x": 3,
+      "y": 8,
+      "txt": "75"
+    },
+    {
+      "x": 2,
+      "y": 8,
+      "txt": "Fun"
+    },
+    {
+      "x": 3,
+      "y": 9,
+      "formulaTxt": "C4:C8 sum",
+      "txt": "1510"
+    },
+    {
+      "x": 2,
+      "y": 9,
+      "txt": "TOTAL"
+    },
+    {
+      "x": 2,
+      "y": 11,
+      "txt": "Edit an amount and watch TOTAL update"
+    }
+  ],
+  "columnWidths": {
+    "2": 60,
+    "3": 30
+  },
+  "rowHeights": {},
+  "formatting": [
+    {
+      "x": 2,
+      "y": 2,
+      "cellColor": [
+        46,
+        139,
+        87
+      ],
+      "txtColor": [
+        255,
+        255,
+        255
+      ],
+      "vPos": "center",
+      "alignment": "center",
+      "fontWeight": "bold",
+      "fontPosture": "regular",
+      "fontSize": 18
+    },
+    {
+      "x": 3,
+      "y": 3,
+      "cellColor": [
+        222,
+        226,
+        230
+      ],
+      "txtColor": [
+        0,
+        0,
+        0
+      ],
+      "vPos": "center",
+      "alignment": "right",
+      "fontWeight": "bold",
+      "fontPosture": "regular",
+      "fontSize": 13
+    },
+    {
+      "x": 2,
+      "y": 3,
+      "cellColor": [
+        222,
+        226,
+        230
+      ],
+      "txtColor": [
+        0,
+        0,
+        0
+      ],
+      "vPos": "center",
+      "alignment": "left",
+      "fontWeight": "bold",
+      "fontPosture": "regular",
+      "fontSize": 13
+    },
+    {
+      "x": 2,
+      "y": 4,
+      "cellColor": [
+        255,
+        255,
+        255
+      ],
+      "txtColor": [
+        0,
+        0,
+        0
+      ],
+      "vPos": "center",
+      "alignment": "left",
+      "fontWeight": "normal",
+      "fontPosture": "regular",
+      "fontSize": 13
+    },
+    {
+      "x": 2,
+      "y": 5,
+      "cellColor": [
+        255,
+        255,
+        255
+      ],
+      "txtColor": [
+        0,
+        0,
+        0
+      ],
+      "vPos": "center",
+      "alignment": "left",
+      "fontWeight": "normal",
+      "fontPosture": "regular",
+      "fontSize": 13
+    },
+    {
+      "x": 2,
+      "y": 6,
+      "cellColor": [
+        255,
+        255,
+        255
+      ],
+      "txtColor": [
+        0,
+        0,
+        0
+      ],
+      "vPos": "center",
+      "alignment": "left",
+      "fontWeight": "normal",
+      "fontPosture": "regular",
+      "fontSize": 13
+    },
+    {
+      "x": 2,
+      "y": 7,
+      "cellColor": [
+        255,
+        255,
+        255
+      ],
+      "txtColor": [
+        0,
+        0,
+        0
+      ],
+      "vPos": "center",
+      "alignment": "left",
+      "fontWeight": "normal",
+      "fontPosture": "regular",
+      "fontSize": 13
+    },
+    {
+      "x": 2,
+      "y": 8,
+      "cellColor": [
+        255,
+        255,
+        255
+      ],
+      "txtColor": [
+        0,
+        0,
+        0
+      ],
+      "vPos": "center",
+      "alignment": "left",
+      "fontWeight": "normal",
+      "fontPosture": "regular",
+      "fontSize": 13
+    },
+    {
+      "x": 3,
+      "y": 9,
+      "cellColor": [
+        255,
+        249,
+        196
+      ],
+      "txtColor": [
+        0,
+        0,
+        0
+      ],
+      "vPos": "center",
+      "alignment": "right",
+      "fontWeight": "bold",
+      "fontPosture": "regular",
+      "fontSize": 13
+    },
+    {
+      "x": 2,
+      "y": 9,
+      "cellColor": [
+        255,
+        249,
+        196
+      ],
+      "txtColor": [
+        0,
+        0,
+        0
+      ],
+      "vPos": "center",
+      "alignment": "left",
+      "fontWeight": "bold",
+      "fontPosture": "regular",
+      "fontSize": 13
+    },
+    {
+      "x": 2,
+      "y": 11,
+      "cellColor": [
+        255,
+        255,
+        255
+      ],
+      "txtColor": [
+        108,
+        117,
+        125
+      ],
+      "vPos": "center",
+      "alignment": "left",
+      "fontWeight": "normal",
+      "fontPosture": "italic",
+      "fontSize": 12
+    }
+  ]
+}

--- a/demos/formulas.json
+++ b/demos/formulas.json
@@ -1,0 +1,107 @@
+{
+  "version": 1,
+  "cells": [
+    {
+      "x": 2, "y": 2, "txt": "RPN Formula Showcase",
+      "mergeStart": true, "mergeEndX": 4, "mergeEndY": 2
+    },
+    { "x": 2, "y": 3, "txt": "Formulas are written in Reverse Polish Notation" },
+
+    { "x": 2, "y": 5, "txt": "3 5 8 * +" },
+    { "x": 3, "y": 5, "formulaTxt": "3 5 8 * +" },
+    { "x": 2, "y": 6, "txt": "2 10 ^" },
+    { "x": 3, "y": 6, "formulaTxt": "2 10 ^" },
+    { "x": 2, "y": 7, "txt": "PI 6 / sin" },
+    { "x": 3, "y": 7, "formulaTxt": "PI 6 / sin" },
+    { "x": 2, "y": 8, "txt": "C5 C6 +  (cell refs)" },
+    { "x": 3, "y": 8, "formulaTxt": "C5 C6 +" },
+
+    { "x": 2, "y": 10, "txt": "Ranges (data in E5:E8):" },
+    { "x": 5, "y": 5, "txt": "10" },
+    { "x": 5, "y": 6, "txt": "20" },
+    { "x": 5, "y": 7, "txt": "30" },
+    { "x": 5, "y": 8, "txt": "40" },
+    { "x": 2, "y": 11, "txt": "E5:E8 sum" },
+    { "x": 3, "y": 11, "formulaTxt": "E5:E8 sum" },
+    { "x": 2, "y": 12, "txt": "E5:E8 prod" },
+    { "x": 3, "y": 12, "formulaTxt": "E5:E8 prod" },
+
+    { "x": 2, "y": 14, "txt": "Matrix (E14:F15):" },
+    { "x": 5, "y": 14, "txt": "1" },
+    { "x": 6, "y": 14, "txt": "2" },
+    { "x": 5, "y": 15, "txt": "3" },
+    { "x": 6, "y": 15, "txt": "4" },
+    { "x": 2, "y": 15, "txt": "E14:F15 det" },
+    { "x": 3, "y": 15, "formulaTxt": "E14:F15 det" }
+  ],
+  "columnWidths": { "2": 100 },
+  "rowHeights": {},
+  "formatting": [
+    {
+      "x": 2, "y": 2,
+      "cellColor": [90, 60, 150], "txtColor": [255, 255, 255],
+      "vPos": "center", "alignment": "center",
+      "fontWeight": "bold", "fontPosture": "regular", "fontSize": 20
+    },
+    {
+      "x": 2, "y": 3,
+      "cellColor": [255, 255, 255], "txtColor": [108, 117, 125],
+      "vPos": "center", "alignment": "left",
+      "fontWeight": "normal", "fontPosture": "italic", "fontSize": 12
+    },
+    {
+      "x": 2, "y": 5,
+      "cellColor": [255, 255, 255], "txtColor": [0, 0, 0],
+      "vPos": "center", "alignment": "left",
+      "fontWeight": "normal", "fontPosture": "regular", "fontSize": 13
+    },
+    {
+      "x": 2, "y": 6,
+      "cellColor": [255, 255, 255], "txtColor": [0, 0, 0],
+      "vPos": "center", "alignment": "left",
+      "fontWeight": "normal", "fontPosture": "regular", "fontSize": 13
+    },
+    {
+      "x": 2, "y": 7,
+      "cellColor": [255, 255, 255], "txtColor": [0, 0, 0],
+      "vPos": "center", "alignment": "left",
+      "fontWeight": "normal", "fontPosture": "regular", "fontSize": 13
+    },
+    {
+      "x": 2, "y": 8,
+      "cellColor": [255, 255, 255], "txtColor": [0, 0, 0],
+      "vPos": "center", "alignment": "left",
+      "fontWeight": "normal", "fontPosture": "regular", "fontSize": 13
+    },
+    {
+      "x": 2, "y": 10,
+      "cellColor": [255, 255, 255], "txtColor": [0, 0, 0],
+      "vPos": "center", "alignment": "left",
+      "fontWeight": "bold", "fontPosture": "regular", "fontSize": 13
+    },
+    {
+      "x": 2, "y": 11,
+      "cellColor": [255, 255, 255], "txtColor": [0, 0, 0],
+      "vPos": "center", "alignment": "left",
+      "fontWeight": "normal", "fontPosture": "regular", "fontSize": 13
+    },
+    {
+      "x": 2, "y": 12,
+      "cellColor": [255, 255, 255], "txtColor": [0, 0, 0],
+      "vPos": "center", "alignment": "left",
+      "fontWeight": "normal", "fontPosture": "regular", "fontSize": 13
+    },
+    {
+      "x": 2, "y": 14,
+      "cellColor": [255, 255, 255], "txtColor": [0, 0, 0],
+      "vPos": "center", "alignment": "left",
+      "fontWeight": "bold", "fontPosture": "regular", "fontSize": 13
+    },
+    {
+      "x": 2, "y": 15,
+      "cellColor": [255, 255, 255], "txtColor": [0, 0, 0],
+      "vPos": "center", "alignment": "left",
+      "fontWeight": "normal", "fontPosture": "regular", "fontSize": 13
+    }
+  ]
+}

--- a/demos/welcome.json
+++ b/demos/welcome.json
@@ -1,0 +1,75 @@
+{
+  "version": 1,
+  "cells": [
+    {
+      "x": 2, "y": 2, "txt": "Welcome to VimiCalc!",
+      "mergeStart": true, "mergeEndX": 5, "mergeEndY": 3
+    },
+    { "x": 2, "y": 5, "txt": "Move around with h j k l (multipliers work: try 5j)" },
+    { "x": 2, "y": 6, "txt": "Press i to insert text, Esc to return to NORMAL mode" },
+    { "x": 2, "y": 7, "txt": "Press = to write an RPN formula, Enter to commit it" },
+    { "x": 2, "y": 8, "txt": "Press ; for commands: :w saves, :help opens the manual" },
+    { "x": 2, "y": 9, "txt": "Zoom: Ctrl+= / Ctrl+- / Ctrl+0, or :zoom 150" },
+    { "x": 2, "y": 10, "txt": "Press v for VISUAL mode; m merges the selected cells" },
+    { "x": 2, "y": 12, "txt": "A formula cell (move onto it to see its RPN):" },
+    { "x": 6, "y": 12, "formulaTxt": "3 5 8 * +" }
+  ],
+  "columnWidths": { "2": 280 },
+  "rowHeights": {},
+  "formatting": [
+    {
+      "x": 2, "y": 2,
+      "cellColor": [33, 111, 190], "txtColor": [255, 255, 255],
+      "vPos": "center", "alignment": "center",
+      "fontWeight": "bold", "fontPosture": "regular", "fontSize": 26
+    },
+    {
+      "x": 2, "y": 5,
+      "cellColor": [255, 255, 255], "txtColor": [0, 0, 0],
+      "vPos": "center", "alignment": "left",
+      "fontWeight": "normal", "fontPosture": "regular", "fontSize": 13
+    },
+    {
+      "x": 2, "y": 6,
+      "cellColor": [255, 255, 255], "txtColor": [0, 0, 0],
+      "vPos": "center", "alignment": "left",
+      "fontWeight": "normal", "fontPosture": "regular", "fontSize": 13
+    },
+    {
+      "x": 2, "y": 7,
+      "cellColor": [255, 255, 255], "txtColor": [0, 0, 0],
+      "vPos": "center", "alignment": "left",
+      "fontWeight": "normal", "fontPosture": "regular", "fontSize": 13
+    },
+    {
+      "x": 2, "y": 8,
+      "cellColor": [255, 255, 255], "txtColor": [0, 0, 0],
+      "vPos": "center", "alignment": "left",
+      "fontWeight": "normal", "fontPosture": "regular", "fontSize": 13
+    },
+    {
+      "x": 2, "y": 9,
+      "cellColor": [255, 255, 255], "txtColor": [0, 0, 0],
+      "vPos": "center", "alignment": "left",
+      "fontWeight": "bold", "fontPosture": "regular", "fontSize": 13
+    },
+    {
+      "x": 2, "y": 10,
+      "cellColor": [255, 255, 255], "txtColor": [0, 0, 0],
+      "vPos": "center", "alignment": "left",
+      "fontWeight": "normal", "fontPosture": "regular", "fontSize": 13
+    },
+    {
+      "x": 2, "y": 12,
+      "cellColor": [255, 255, 255], "txtColor": [0, 0, 0],
+      "vPos": "center", "alignment": "left",
+      "fontWeight": "normal", "fontPosture": "italic", "fontSize": 13
+    },
+    {
+      "x": 6, "y": 12,
+      "cellColor": [223, 240, 216], "txtColor": [0, 0, 0],
+      "vPos": "center", "alignment": "center",
+      "fontWeight": "bold", "fontPosture": "regular", "fontSize": 13
+    }
+  ]
+}

--- a/src/main/java/vimicalc/controller/EditorOperations.java
+++ b/src/main/java/vimicalc/controller/EditorOperations.java
@@ -1,6 +1,7 @@
 package vimicalc.controller;
 
 import vimicalc.model.*;
+import vimicalc.view.Positions;
 
 import static vimicalc.view.Defaults.*;
 
@@ -67,6 +68,41 @@ public class EditorOperations {
         ctrl.camera.picture.take(ctrl.gc, ctrl.sheet, ctrl.selectedCoords, ctrl.camera.getAbsX(), ctrl.camera.getAbsY());
         ctrl.firstRow.draw(ctrl.gc);
         ctrl.firstCol.draw(ctrl.gc);
+    }
+
+    /** Zooms the grid view in by one step. */
+    public void zoomIn() {
+        applyZoom(ctrl.camera.picture.metadata().getZoom() * ZOOM_STEP);
+    }
+
+    /** Zooms the grid view out by one step. */
+    public void zoomOut() {
+        applyZoom(ctrl.camera.picture.metadata().getZoom() / ZOOM_STEP);
+    }
+
+    /** Resets the grid view zoom to 100%. */
+    public void zoomReset() {
+        applyZoom(DEFAULT_ZOOM);
+    }
+
+    /**
+     * Applies a new zoom factor (clamped by {@link Positions#setZoom(double)}),
+     * re-renders the grid, and keeps the cursor visible: the camera offset is
+     * never mutated by zoom itself, but zooming in can push the selected cell
+     * past the viewport edge, so the standard scroll correction runs after.
+     *
+     * @param newZoom the requested zoom factor (1.0 = 100%)
+     */
+    private void applyZoom(double newZoom) {
+        Positions positions = ctrl.camera.picture.metadata();
+        positions.setZoom(newZoom);
+        ctrl.camera.picture.take(ctrl.gc, ctrl.sheet, ctrl.selectedCoords, ctrl.camera.getAbsX(), ctrl.camera.getAbsY());
+        ctrl.camera.ready();
+        ctrl.cellSelector.readCell(ctrl.camera.picture.data());
+        scrollCursorIntoView();
+        ctrl.camera.picture.resend(ctrl.gc, ctrl.camera.getAbsX(), ctrl.camera.getAbsY());
+        ctrl.cellSelector.readCell(ctrl.camera.picture.data());
+        ctrl.infoBar.setInfobarTxt("Zoom: " + Math.round(positions.getZoom() * 100) + "%");
     }
 
     /**

--- a/src/main/java/vimicalc/controller/KeyCommand.java
+++ b/src/main/java/vimicalc/controller/KeyCommand.java
@@ -27,6 +27,7 @@ import static vimicalc.utils.Conversions.isNumber;
  *   <li><b>Cell ref:</b> ${coords}{movement} (use cell value as multiplier; last char must be a movement key)</li>
  *   <li><b>Range operations:</b> {func}{multiplier}{dir} (e.g. "d5j" to delete 5 cells down)</li>
  *   <li><b>Quit shortcuts:</b> ZZ (save+quit), ZQ (quit without saving)</li>
+ *   <li><b>Zoom:</b> Ctrl-= (zoom in), Ctrl-- (zoom out), Ctrl-0 (reset)</li>
  * </ul>
  */
 public class KeyCommand {
@@ -106,6 +107,33 @@ public class KeyCommand {
             }
             case C -> {
                 if (event.isControlDown()) {
+                    expr = "";
+                    ctrl.infoBar.setIBarExpr("");
+                    return;
+                }
+            }
+            // Zoom shortcuts consume the event only with Ctrl held; otherwise
+            // the keys keep their NORMAL-mode meaning ('=' enters FORMULA
+            // mode, '0' stays a multiplier digit).
+            case EQUALS, PLUS, ADD -> {
+                if (event.isControlDown()) {
+                    ops.zoomIn();
+                    expr = "";
+                    ctrl.infoBar.setIBarExpr("");
+                    return;
+                }
+            }
+            case MINUS, SUBTRACT -> {
+                if (event.isControlDown()) {
+                    ops.zoomOut();
+                    expr = "";
+                    ctrl.infoBar.setIBarExpr("");
+                    return;
+                }
+            }
+            case DIGIT0, NUMPAD0 -> {
+                if (event.isControlDown()) {
+                    ops.zoomReset();
                     expr = "";
                     ctrl.infoBar.setIBarExpr("");
                     return;

--- a/src/main/java/vimicalc/model/Command.java
+++ b/src/main/java/vimicalc/model/Command.java
@@ -4,6 +4,7 @@ import org.jetbrains.annotations.NotNull;
 import vimicalc.view.Formatting;
 
 import static vimicalc.view.Defaults.DEFAULT_FONT_SIZE;
+import static vimicalc.view.Defaults.DEFAULT_ZOOM;
 
 /**
  * Interprets colon commands entered in COMMAND mode (e.g. {@code :w}, {@code :q},
@@ -25,6 +26,7 @@ import static vimicalc.view.Defaults.DEFAULT_FONT_SIZE;
  *   <li>{@code :italicTxt} — toggle italic text on the current cell</li>
  *   <li>{@code :fontSize [px]} — set the font size (no argument resets to default)</li>
  *   <li>{@code :fontWeight [bold|normal|100-900]} — set the font weight (no argument resets to normal)</li>
+ *   <li>{@code :zoom [25-400]} — set the view zoom percentage (no argument resets to 100%)</li>
  * </ul>
  *
  * <p>Color arguments accept the built-in names (red, green, blue, white, black,
@@ -123,6 +125,16 @@ public class Command extends Interpretable {
                         command[1].getVal() < 4 || command[1].getVal() > 200)
                         throw new Exception("fontSize expects a size between 4 and 200.");
                     fontSize((int) command[1].getVal(), sheet);
+                }
+            }
+            case "zoom" -> {
+                // Global view zoom — unlike :resCol/:fontSize, ignores xC/yC.
+                if (command.length == 1) sheet.getPositions().setZoom(DEFAULT_ZOOM);
+                else {
+                    if (command[1].isFunction() ||
+                        command[1].getVal() < 25 || command[1].getVal() > 400)
+                        throw new Exception("zoom expects a percentage between 25 and 400.");
+                    sheet.getPositions().setZoom(command[1].getVal() / 100);
                 }
             }
             case "fontWeight" -> {

--- a/src/main/java/vimicalc/view/CellSelector.java
+++ b/src/main/java/vimicalc/view/CellSelector.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.function.Supplier;
 
+import static vimicalc.view.Defaults.DEFAULT_FONT_SIZE;
 import static vimicalc.view.Defaults.GUTTER_W;
 import static vimicalc.view.Defaults.HEADER_H;
 
@@ -109,12 +110,13 @@ public class CellSelector extends simpleRect {
                 prevFont.getFamily(),
                 f.setFXFontWeight(f.getFontWeight()),
                 f.setFXFontPosture(f.getFontPosture()),
-                f.getFontSize()
+                f.getFontSize() * picPositions.getZoom()
             ));
         } else {
             gc.setFill(Color.BLACK);
             gc.setTextBaseline(VPos.CENTER);
             gc.setTextAlign(TextAlignment.CENTER);
+            gc.setFont(Font.font(prevFont.getFamily(), DEFAULT_FONT_SIZE * picPositions.getZoom()));
         }
         gc.fillText(selectedCell.txt()
             , x + (float) w/2

--- a/src/main/java/vimicalc/view/Defaults.java
+++ b/src/main/java/vimicalc/view/Defaults.java
@@ -23,6 +23,14 @@ public final class Defaults {
     public static final int HEADER_H = DEFAULT_CELL_H;
     /** Default font size in points (matches the JavaFX canvas default font). */
     public static final int DEFAULT_FONT_SIZE = 13;
+    /** Default view zoom factor (100%). */
+    public static final double DEFAULT_ZOOM = 1.0;
+    /** Minimum view zoom factor (25%). */
+    public static final double MIN_ZOOM = 0.25;
+    /** Maximum view zoom factor (400%). */
+    public static final double MAX_ZOOM = 4.0;
+    /** Multiplicative step applied per zoom-in/zoom-out key press. */
+    public static final double ZOOM_STEP = 1.1;
     /** Default cell background color. */
     public static final Color DEFAULT_CELL_C = Color.WHITE;
     /** Default cell text color. */

--- a/src/main/java/vimicalc/view/FirstCol.java
+++ b/src/main/java/vimicalc/view/FirstCol.java
@@ -3,8 +3,11 @@ package vimicalc.view;
 import javafx.geometry.VPos;
 import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.paint.Color;
+import javafx.scene.text.Font;
 import javafx.scene.text.TextAlignment;
 import org.jetbrains.annotations.NotNull;
+
+import static vimicalc.view.Defaults.DEFAULT_FONT_SIZE;
 
 /**
  * The row number column displayed on the left side of the spreadsheet.
@@ -39,6 +42,10 @@ public class FirstCol extends simpleRect {
         gc.setFill(Color.BLACK);
         gc.setTextAlign(TextAlignment.CENTER);
         gc.setTextBaseline(VPos.CENTER);
+        // Scale the label font with the view zoom so headers grow with the
+        // grid; fillText's max-width squeezes labels that outgrow the gutter.
+        Font prevFont = gc.getFont();
+        gc.setFont(Font.font(prevFont.getFamily(), DEFAULT_FONT_SIZE * picPositions.getZoom()));
         int cellHeight;
         for (int yC = picPositions.getFirstYC(); yC <= picPositions.getLastYC(); yC++) {
             cellHeight = picPositions.getCellAbsYs()[yC+1] - picPositions.getCellAbsYs()[yC];
@@ -47,5 +54,6 @@ public class FirstCol extends simpleRect {
                 , picPositions.getCellAbsYs()[yC] - camera.getAbsY() + y + (float) cellHeight/2
                 , w);
         }
+        gc.setFont(prevFont);
     }
 }

--- a/src/main/java/vimicalc/view/FirstRow.java
+++ b/src/main/java/vimicalc/view/FirstRow.java
@@ -2,10 +2,12 @@ package vimicalc.view;
 
 import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.paint.Color;
+import javafx.scene.text.Font;
 import javafx.scene.text.TextAlignment;
 import org.jetbrains.annotations.NotNull;
 
 import static vimicalc.utils.Conversions.toAlpha;
+import static vimicalc.view.Defaults.DEFAULT_FONT_SIZE;
 
 /**
  * The column header row displayed at the top of the spreadsheet.
@@ -39,6 +41,10 @@ public class FirstRow extends simpleRect {
         super.draw(gc);
         gc.setFill(Color.BLACK);
         gc.setTextAlign(TextAlignment.CENTER);
+        // Scale the label font with the view zoom so headers grow with the
+        // grid; fillText's max-width squeezes labels that outgrow the header.
+        Font prevFont = gc.getFont();
+        gc.setFont(Font.font(prevFont.getFamily(), DEFAULT_FONT_SIZE * picPositions.getZoom()));
         int cellWidth;
         for (int xC = picPositions.getFirstXC(); xC <= picPositions.getLastXC(); xC++) {
             cellWidth = picPositions.getCellAbsXs()[xC+1] - picPositions.getCellAbsXs()[xC];
@@ -47,5 +53,6 @@ public class FirstRow extends simpleRect {
                 , (float) h/2
                 , cellWidth);
         }
+        gc.setFont(prevFont);
     }
 }

--- a/src/main/java/vimicalc/view/Formatting.java
+++ b/src/main/java/vimicalc/view/Formatting.java
@@ -376,6 +376,24 @@ public class Formatting {
      * @param txt the text content to display
      */
     public void renderCell(@NotNull GraphicsContext gc, int x, int y, int w, int h, String txt) {
+        renderCell(gc, x, y, w, h, txt, 1.0);
+    }
+
+    /**
+     * Renders a cell with this formatting's colors, alignment, and font style,
+     * multiplying the view zoom factor into the font size at render time. The
+     * stored {@code fontSize} is untouched, so per-cell {@code :fontSize}
+     * values and persistence are unaffected by zoom.
+     *
+     * @param gc   the graphics context
+     * @param x    the cell's x-coordinate (pixels)
+     * @param y    the cell's y-coordinate (pixels)
+     * @param w    the cell's width (pixels)
+     * @param h    the cell's height (pixels)
+     * @param txt  the text content to display
+     * @param zoom the view zoom factor (1.0 = 100%)
+     */
+    public void renderCell(@NotNull GraphicsContext gc, int x, int y, int w, int h, String txt, double zoom) {
         // Save shared GC state so this cell's style doesn't leak into
         // cells rendered after it in the same pass.
         Font prevFont = gc.getFont();
@@ -392,7 +410,7 @@ public class Formatting {
             prevFont.getFamily(),
             setFXFontWeight(fontWeight),
             setFXFontPosture(fontPosture),
-            fontSize
+            fontSize * zoom
         ));
         gc.fillText(txt, x + (float)w/2, y + (float)h/2, w);
 

--- a/src/main/java/vimicalc/view/HelpMenu.java
+++ b/src/main/java/vimicalc/view/HelpMenu.java
@@ -56,6 +56,8 @@ public class HelpMenu extends simpleRect {
         "\t Formatting commands: :cellColor and :txtColor (CSS color names or #hex values),",
         "\t :fontSize [px], :fontWeight [bold|normal|100-900], :boldTxt and :italicTxt toggles.",
         "\t Formatting commands without an argument reset the property to its default.",
+        "\t View zoom: :zoom [25-400] sets the zoom percentage (no argument resets to 100%),",
+        "\t or use Ctrl-= / Ctrl-- / Ctrl-0 in NORMAL mode to zoom in / out / reset.",
         "\n",
         "And then we have KeyCommands, which are basically actions made up of keyboard shortcuts entered in",
         "NORMAL mode. They appear at the bottom right of the window as you type.",

--- a/src/main/java/vimicalc/view/Picture.java
+++ b/src/main/java/vimicalc/view/Picture.java
@@ -3,6 +3,7 @@ package vimicalc.view;
 import javafx.geometry.VPos;
 import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.paint.Color;
+import javafx.scene.text.Font;
 import javafx.scene.text.TextAlignment;
 import org.jetbrains.annotations.NotNull;
 import vimicalc.model.Cell;
@@ -13,6 +14,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static vimicalc.view.Defaults.DEFAULT_FONT_SIZE;
 import static vimicalc.view.Defaults.GUTTER_W;
 import static vimicalc.view.Defaults.HEADER_H;
 
@@ -148,6 +150,10 @@ public class Picture extends simpleRect {
         gc.setFill(Color.BLACK);
         gc.setTextBaseline(VPos.CENTER);
         gc.setTextAlign(TextAlignment.CENTER);
+        // Scale the default font so unformatted cells zoom with the grid;
+        // formatted cells scale via the zoom argument to renderCell.
+        Font prevFont = gc.getFont();
+        gc.setFont(Font.font(prevFont.getFamily(), DEFAULT_FONT_SIZE * metadata.getZoom()));
         int cellHeight, cellWidth;
         for (Cell c : visibleCells) {
             if (c.isMergeStart()) {
@@ -169,7 +175,8 @@ public class Picture extends simpleRect {
                     metadata.getCellAbsYs()[c.yCoord()] - absY + HEADER_H,
                     cellWidth,
                     cellHeight,
-                    c.txt()
+                    c.txt(),
+                    metadata.getZoom()
                 );
             } catch (Exception ignored) {
                 gc.fillText(
@@ -197,9 +204,11 @@ public class Picture extends simpleRect {
                     metadata.getCellAbsYs()[formattingYC] - absY + HEADER_H,
                     metadata.getCellAbsXs()[formattingXC+1] - metadata.getCellAbsXs()[formattingXC],
                     metadata.getCellAbsYs()[formattingYC+1] - metadata.getCellAbsYs()[formattingYC],
-                    ""
+                    "",
+                    metadata.getZoom()
                 );
             }
         }
+        gc.setFont(prevFont);
     }
 }

--- a/src/main/java/vimicalc/view/Positions.java
+++ b/src/main/java/vimicalc/view/Positions.java
@@ -4,6 +4,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 
+import static vimicalc.view.Defaults.DEFAULT_ZOOM;
+import static vimicalc.view.Defaults.MAX_ZOOM;
+import static vimicalc.view.Defaults.MIN_ZOOM;
+
 /**
  * Manages the pixel-level layout of the spreadsheet grid.
  *
@@ -26,6 +30,11 @@ public class Positions {
     private HashMap<Integer, Integer> xOffsets;
     private HashMap<Integer, Integer> yOffsets;
     private int[] cellAbsXs, cellAbsYs;
+    /**
+     * The view zoom factor multiplied into every cell size during
+     * {@link #generate(int, int)}. Session-only view state — never persisted.
+     */
+    private double zoom = DEFAULT_ZOOM;
 
     /**
      * Creates a new position layout manager.
@@ -49,15 +58,20 @@ public class Positions {
         maxYC = 0;
     }
 
+    /** Scales a pixel size by the current zoom factor. */
+    private int scaled(int size) {
+        return (int) Math.round(size * zoom);
+    }
+
     private int xOuterEdge(int xInnerEdge, int xC) {
-        return xInnerEdge + picW + 2 * DCW +
+        return xInnerEdge + picW + scaled(2 * DCW +
                ((xOffsets.get(xC) == null) ? 0 : xOffsets.get(xC)) +
-               ((xOffsets.get(xC + 1) == null) ? 0 : xOffsets.get(xC + 1));
+               ((xOffsets.get(xC + 1) == null) ? 0 : xOffsets.get(xC + 1)));
     }
     private int yOuterEdge(int yInnerEdge, int yC) {
-        return yInnerEdge + picH + 2 * DCH +
+        return yInnerEdge + picH + scaled(2 * DCH +
                ((yOffsets.get(yC) == null) ? 0 : yOffsets.get(yC)) +
-               ((yOffsets.get(yC + 1) == null) ? 0 : yOffsets.get(yC + 1));
+               ((yOffsets.get(yC + 1) == null) ? 0 : yOffsets.get(yC + 1)));
     }
 
     /**
@@ -76,6 +90,10 @@ public class Positions {
         System.out.println("Generating metadata...");
         ArrayList<Integer> cellAbsXsLong = new ArrayList<>(), cellAbsYsLong = new ArrayList<>();
         cellAbsXsLong.add(0); cellAbsYsLong.add(0);
+        // The seeds stay unscaled by zoom: cellAbsXs[1] must equal GUTTER_W and
+        // cellAbsYs[1] must equal HEADER_H so the grid stays flush against the
+        // fixed-size chrome at the camera home position (Camera.scrollBy clamps
+        // to those values).
         int currAbsX = DCW/2, currAbsY = DCH, xC = 1, yC = 1;
         boolean firstXCFound = false, lastXCFound = false,
                 firstYCFound = false, lastYCFound = false;
@@ -88,7 +106,10 @@ public class Positions {
                 firstXCFound = true;
             }
             cellAbsXsLong.add(currAbsX);
-            currAbsX += DCW + xOffset;
+            // Scaling (default + offset) as one unit makes :resCol sizes zoom
+            // proportionally without mutating the stored offset maps, and
+            // per-increment rounding cannot accumulate drift across columns.
+            currAbsX += scaled(DCW + xOffset);
             if (currAbsX > xInnerEdge + picW && !lastXCFound) {
                 System.out.println(currAbsX + " " + xInnerEdge + " " + picW + " " + DCW);
                 lastXC = xC;
@@ -107,7 +128,7 @@ public class Positions {
                 firstYCFound = true;
             }
             cellAbsYsLong.add(currAbsY);
-            currAbsY += DCH + yOffset;
+            currAbsY += scaled(DCH + yOffset);
             if (currAbsY > yInnerEdge + picH && !lastYCFound) {
                 System.out.println(currAbsY + " " + yInnerEdge + " " + picH + " " + DCH);
                 lastYC = yC;
@@ -159,6 +180,22 @@ public class Positions {
             xOffsets.put(newOffset[0], newOffset[1]);
         else
             yOffsets.put(newOffset[0], newOffset[1]);
+        regenerate();
+    }
+
+    /** @return the current view zoom factor */
+    public double getZoom() {
+        return zoom;
+    }
+
+    /**
+     * Sets the view zoom factor, clamped to {@code [MIN_ZOOM, MAX_ZOOM]},
+     * and regenerates positions at the last viewport edges.
+     *
+     * @param zoom the new zoom factor (1.0 = 100%)
+     */
+    public void setZoom(double zoom) {
+        this.zoom = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, zoom));
         regenerate();
     }
 

--- a/src/test/java/vimicalc/controller/KeyCommandManualTests.md
+++ b/src/test/java/vimicalc/controller/KeyCommandManualTests.md
@@ -199,3 +199,40 @@ it — Vim-like behavior, per issue #24.
 ### 10.5 Entering COMMAND mode to escape
 1. Type `y` (expression waiting for second char)
 2. Press `;` — enters COMMAND mode, expression resets
+
+---
+
+## 11. Zoom (Ctrl+=, Ctrl+-, Ctrl+0, :zoom)
+
+### 11.1 Zoom in / out / reset with keys
+1. Press Ctrl+`=` three times — cells, their text, and the row/column header
+   labels all grow together; the status/info bars stay their normal size;
+   info bar shows "Zoom: 133%"
+2. Press Ctrl+`-` once — one step back down, info bar shows "Zoom: 121%"
+3. Press Ctrl+`0` — layout returns exactly to the original size,
+   info bar shows "Zoom: 100%"
+
+### 11.2 Un-modified keys keep their meaning
+1. Press `=` (no Ctrl) — enters FORMULA mode as usual; press Escape
+2. Press `1` `0` `j` — cursor moves down 10 cells (the `0` still works
+   as a multiplier digit); the view does not zoom
+
+### 11.3 :zoom command
+1. Press `;` then type `zoom 200` and press Enter — cells double in size
+2. Press `;` then type `zoom` (no argument) and press Enter — back to 100%
+3. Press `;` then type `zoom 10` and press Enter — info bar shows the error
+   "zoom expects a percentage between 25 and 400."
+
+### 11.4 Zoom interacts with scroll and resized cells
+1. Navigate far from the origin (e.g. `g` T40) so the view is scrolled
+2. Press Ctrl+`=` a few times — the cursor stays visible (the view
+   auto-scrolls if the zoomed cell would fall off the edge)
+3. Press Ctrl+`0`, then on some column run `;` `resCol 40` Enter
+4. Press Ctrl+`=` — the widened column grows proportionally
+   (stays wider than its neighbors); Ctrl+`0` restores it to exactly
+   default + 40 pixels
+
+### 11.5 Zoom with merged cells
+1. Select a block in VISUAL mode (`v`, move, `m`) to merge it
+2. Press Ctrl+`=` — the merged block scales as one region and its
+   text scales with it

--- a/src/test/java/vimicalc/controller/ViewportSyncUiTest.java
+++ b/src/test/java/vimicalc/controller/ViewportSyncUiTest.java
@@ -143,6 +143,32 @@ class ViewportSyncUiTest {
         assertCursorGridAligned();
     }
 
+    @Test
+    void zoomKeepsCursorAlignedAndCameraClamped(FxRobot robot) {
+        Positions pos = controller.camera.picture.metadata();
+        int prevAbsX = controller.camera.getAbsX(), prevAbsY = controller.camera.getAbsY();
+
+        robot.press(KeyCode.CONTROL).type(KeyCode.EQUALS).release(KeyCode.CONTROL);
+        assertEquals(Math.round(DEFAULT_CELL_W * ZOOM_STEP), pos.getCellAbsXs()[3] - pos.getCellAbsXs()[2],
+            "one zoom-in step must scale column widths by ZOOM_STEP");
+        assertEquals(prevAbsX, controller.camera.getAbsX(), "zoom must not move the camera");
+        assertEquals(prevAbsY, controller.camera.getAbsY(), "zoom must not move the camera");
+        assertCursorGridAligned();
+
+        robot.press(KeyCode.CONTROL).type(KeyCode.DIGIT0).release(KeyCode.CONTROL);
+        assertEquals(1.0, pos.getZoom(), "Ctrl-0 must reset the zoom factor");
+        assertEquals(DEFAULT_CELL_W, pos.getCellAbsXs()[3] - pos.getCellAbsXs()[2],
+            "Ctrl-0 must restore the default column width");
+        assertCursorGridAligned();
+
+        robot.type(KeyCode.SEMICOLON);
+        typeText(robot, "zoom 200");
+        robot.type(KeyCode.ENTER);
+        assertEquals(2.0, pos.getZoom(), ":zoom 200 must set the zoom factor to 2.0");
+        assertEquals(2 * DEFAULT_CELL_W, pos.getCellAbsXs()[3] - pos.getCellAbsXs()[2]);
+        assertCursorGridAligned();
+    }
+
     /**
      * The issue #30 invariant: the cursor's pixel rectangle equals the shared
      * viewport formula applied to its logical cell — the same arithmetic the

--- a/src/test/java/vimicalc/model/CommandTest.java
+++ b/src/test/java/vimicalc/model/CommandTest.java
@@ -4,6 +4,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import vimicalc.view.Formatting;
+import vimicalc.view.Positions;
+
+import java.util.HashMap;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -120,6 +123,45 @@ class CommandTest {
             run("cellColor teal");
             run("cellColor notacolor");
             assertNull(sheet.findFormatting(2, 3));
+        }
+    }
+
+    // ── :zoom ──
+
+    @Nested
+    class ZoomTests {
+        @BeforeEach
+        void setUpPositions() {
+            // :zoom acts on the sheet's Positions, which the bare Sheet from
+            // the outer setUp doesn't have.
+            sheet.setPositions(new Positions(852, 552, 96, 24, new HashMap<>(), new HashMap<>()));
+            sheet.getPositions().generate(48, 24);
+        }
+
+        @Test
+        void setsZoomFromPercent() throws Exception {
+            run("zoom 150");
+            assertEquals(1.5, sheet.getPositions().getZoom());
+        }
+
+        @Test
+        void noArgumentResetsToDefault() throws Exception {
+            run("zoom 150");
+            run("zoom");
+            assertEquals(1.0, sheet.getPositions().getZoom());
+        }
+
+        @Test
+        void outOfRangePercentThrows() {
+            Exception low = assertThrows(Exception.class, () -> run("zoom 10"));
+            assertTrue(low.getMessage().contains("zoom"));
+            Exception high = assertThrows(Exception.class, () -> run("zoom 500"));
+            assertTrue(high.getMessage().contains("zoom"));
+        }
+
+        @Test
+        void nonNumericPercentThrows() {
+            assertThrows(Exception.class, () -> run("zoom huge"));
         }
     }
 

--- a/src/test/java/vimicalc/view/PositionsTest.java
+++ b/src/test/java/vimicalc/view/PositionsTest.java
@@ -74,4 +74,70 @@ class PositionsTest {
         assertEquals(24 + 13, ys[3] - ys[2], "the target row gains exactly the offset");
         assertEquals(24, ys[4] - ys[3], "rows after the target keep the default height");
     }
+
+    // ── Zoom ──
+
+    @Test
+    void zoomScalesDefaultCellSizes() {
+        positions.setZoom(2.0);
+
+        int[] xs = positions.getCellAbsXs(), ys = positions.getCellAbsYs();
+        assertEquals(192, xs[3] - xs[2], "column widths double at 200% zoom");
+        assertEquals(48, ys[3] - ys[2], "row heights double at 200% zoom");
+    }
+
+    @Test
+    void zoomKeepsTheHomeOriginUnscaled() {
+        positions.setZoom(2.0);
+
+        assertEquals(48, positions.getCellAbsXs()[1],
+            "cellAbsXs[1] must stay GUTTER_W so the grid stays flush with the fixed chrome");
+        assertEquals(24, positions.getCellAbsYs()[1],
+            "cellAbsYs[1] must stay HEADER_H so the grid stays flush with the fixed chrome");
+    }
+
+    @Test
+    void zoomScalesResizedColumnsProportionallyWithoutMutatingOffsets() {
+        positions.applyOffset(new int[]{3, 31}, true);
+
+        positions.setZoom(2.0);
+
+        int[] xs = positions.getCellAbsXs();
+        assertEquals(2 * (96 + 31), xs[4] - xs[3], "the resized column scales as (default + offset) * zoom");
+        assertEquals(192, xs[3] - xs[2], "other columns scale from the default width");
+        assertEquals(31, positions.getxOffsets().get(3), "the stored offset map is not mutated by zoom");
+    }
+
+    @Test
+    void zoomClampsToTheAllowedRange() {
+        positions.setZoom(10.0);
+        assertEquals(4.0, positions.getZoom(), "zoom clamps to the maximum");
+
+        positions.setZoom(0.01);
+        assertEquals(0.25, positions.getZoom(), "zoom clamps to the minimum");
+    }
+
+    @Test
+    void zoomStepsProduceUniformColumnWidths() {
+        positions.setZoom(1.1);
+
+        int[] xs = positions.getCellAbsXs();
+        for (int xC = 2; xC <= 5; xC++)
+            assertEquals(106, xs[xC + 1] - xs[xC],
+                "per-increment rounding must not accumulate drift across columns");
+    }
+
+    @Test
+    void resetZoomRestoresTheExactOriginalLayout() {
+        int[] xs = positions.getCellAbsXs().clone(), ys = positions.getCellAbsYs().clone();
+        int firstXC = positions.getFirstXC(), lastXC = positions.getLastXC();
+
+        positions.setZoom(1.7);
+        positions.setZoom(1.0);
+
+        assertArrayEquals(xs, positions.getCellAbsXs());
+        assertArrayEquals(ys, positions.getCellAbsYs());
+        assertEquals(firstXC, positions.getFirstXC());
+        assertEquals(lastXC, positions.getLastXC());
+    }
 }


### PR DESCRIPTION
## What

Adds a global **view zoom** for the spreadsheet grid, plus a few demo files under `demos/`.

- **Ctrl+=** zoom in, **Ctrl+-** zoom out, **Ctrl+0** reset (NORMAL mode)
- **`:zoom [25-400]`** colon command; no argument resets to 100%
- Multiplicative ×1.1 steps, clamped to 25%–400%; session-only view state (never persisted)
- Cells, cell text, and row/column header labels scale together; status/info bars stay fixed
- Info bar reports the current level (e.g. `Zoom: 133%`)

## How

- The zoom factor lives on `Positions` (the shared layout source of truth) and is multiplied into each `(default + offset)` cell increment in `generate()` — so `:resCol`/`:resRow` sizes zoom proportionally **without mutating the stored offset maps**, per-increment rounding can't accumulate drift, and resetting to 100% restores the exact original layout. The origin seeds stay unscaled so the grid stays flush with the fixed chrome at camera home.
- Fonts scale at render time via a zoom-aware `Formatting.renderCell` overload (threaded through `Picture`, `CellSelector`, `FirstCol`, `FirstRow`); stored per-cell `:fontSize` values and file persistence are untouched.
- Zoom never moves the camera offset; the Ctrl-key path runs `scrollCursorIntoView()` afterward so zooming in can't strand the cursor off-viewport.
- Unmodified keys keep their meanings: bare `=` still enters FORMULA mode, `0` still works in counts like `10j`.

## Demos

`demos/welcome.json` (feature tour incl. the zoom keys), `demos/budget.json` (sum formula with live dependency updates), `demos/formulas.json` (RPN showcase: arithmetic, cell refs, ranges, det). Open with `./gradlew run --args="demos/welcome.json"`.

## Testing

- 6 new `PositionsTest` cases: scaling, home-origin invariant, proportional offset scaling, clamping, rounding uniformity, exact reset
- 4 new `CommandTest` cases for `:zoom` (set / reset / range / non-numeric)
- New `ViewportSyncUiTest` TestFX case: cursor/grid alignment and camera clamping through Ctrl+=, Ctrl+0, and `:zoom 200`
- Full suite passes (212 tests); demos verified to load and evaluate via headless screenshot probes
- `KeyCommandManualTests.md` gains a `## 11 Zoom` section; help menu and Javadoc command lists updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)