### PR TITLE
Decouple grid-viewport geometry from chrome objects

### DIFF
--- a/src/main/java/vimicalc/controller/Controller.java
+++ b/src/main/java/vimicalc/controller/Controller.java
@@ -814,6 +814,16 @@ public class Controller implements Initializable {
     }
 
     /**
+     * Returns the y coordinate of the bottom edge of the grid viewport, i.e.
+     * where the sheet's drawable area ends and the status bar begins.
+     *
+     * @return the grid viewport's bottom edge, in canvas pixels
+     */
+    int viewportBottom() {
+        return CANVAS_H - STATUS_BAR_H - INFO_BAR_H;
+    }
+
+    /**
      * Resets all UI components and state to their defaults. Called on
      * initialization, after loading a file, and from {@link Sheet#readFile(String)}.
      */
@@ -822,7 +832,7 @@ public class Controller implements Initializable {
             GUTTER_W,
             HEADER_H,
             CANVAS_W-GUTTER_W,
-            CANVAS_H-3*DEFAULT_CELL_H-4,
+            viewportBottom()-HEADER_H,
             DEFAULT_CELL_C,
             sheet.getPositions(),
             sheet.getCellsFormatting()
@@ -854,14 +864,14 @@ public class Controller implements Initializable {
         );
         coordsInfo = new CoordsInfo(
             CANVAS_W,
-            CANVAS_H-2*DEFAULT_CELL_H-4,
-            DEFAULT_CELL_H + 4
+            viewportBottom(),
+            STATUS_BAR_H
         );
         firstCol = new FirstCol(
             0,
             HEADER_H,
             GUTTER_W,
-            CANVAS_H-3*DEFAULT_CELL_H-4,
+            viewportBottom()-HEADER_H,
             Color.LIGHTBLUE,
             camera,
             camera.picture.metadata()
@@ -877,16 +887,16 @@ public class Controller implements Initializable {
         );
         infoBar = new InfoBar(
             0,
-            CANVAS_H-DEFAULT_CELL_H,
+            CANVAS_H-INFO_BAR_H,
             CANVAS_W,
-            DEFAULT_CELL_H,
+            INFO_BAR_H,
             DEFAULT_CELL_C
         );
         statusBar = new StatusBar(
             0,
-            CANVAS_H-2*DEFAULT_CELL_H-4,
+            viewportBottom(),
             CANVAS_W,
-            DEFAULT_CELL_H+4,
+            STATUS_BAR_H,
             Color.LIGHTGREEN,
             () -> currMode
         );

--- a/src/main/java/vimicalc/controller/EditorOperations.java
+++ b/src/main/java/vimicalc/controller/EditorOperations.java
@@ -61,7 +61,7 @@ public class EditorOperations {
         int bottom = ys[yc+1] - ctrl.camera.getAbsY() + HEADER_H;
         int dx = right > ctrl.CANVAS_W ? right - ctrl.CANVAS_W
                : left < GUTTER_W ? left - GUTTER_W : 0;
-        int dy = bottom > ctrl.statusBar.getY() ? bottom - ctrl.statusBar.getY()
+        int dy = bottom > ctrl.viewportBottom() ? bottom - ctrl.viewportBottom()
                : top < HEADER_H ? top - HEADER_H : 0;
         if (dx == 0 && dy == 0) return;
         ctrl.camera.scrollBy(dx, dy);

--- a/src/main/java/vimicalc/view/Defaults.java
+++ b/src/main/java/vimicalc/view/Defaults.java
@@ -21,6 +21,10 @@ public final class Defaults {
     public static final int GUTTER_W = DEFAULT_CELL_W / 2;
     /** Height in pixels of the column-letter header row ({@link FirstRow}) on the top edge. */
     public static final int HEADER_H = DEFAULT_CELL_H;
+    /** Height in pixels of the status bar ({@link StatusBar}) row below the grid. */
+    public static final int STATUS_BAR_H = DEFAULT_CELL_H + 4;
+    /** Height in pixels of the information bar ({@link InfoBar}) at the bottom edge. */
+    public static final int INFO_BAR_H = DEFAULT_CELL_H;
     /** Default font size in points (matches the JavaFX canvas default font). */
     public static final int DEFAULT_FONT_SIZE = 13;
     /** Default view zoom factor (100%). */

--- a/src/test/java/vimicalc/controller/ViewportSyncUiTest.java
+++ b/src/test/java/vimicalc/controller/ViewportSyncUiTest.java
@@ -137,7 +137,7 @@ class ViewportSyncUiTest {
 
         for (int i = 0; i < 21; i++) robot.type(KeyCode.J);
         assertTrue(controller.camera.getAbsY() > HEADER_H, "downward scroll expected");
-        assertEquals(controller.statusBar.getY(),
+        assertEquals(controller.viewportBottom(),
             controller.cellSelector.getY() + controller.cellSelector.getH(),
             "after a scroll the cursor cell must sit flush against the bottom edge");
         assertCursorGridAligned();


### PR DESCRIPTION
Closes #42. Part 1 of the canvas→FXML chrome migration (#42 → #43 → #44 → #45; follow-up #46).

## What

Pure no-op refactor: the grid's bottom boundary was defined implicitly as `statusBar.getY()`, which blocks moving the status bar off the canvas (#43).

- `Defaults`: new `STATUS_BAR_H` (= `DEFAULT_CELL_H + 4` = 28) and `INFO_BAR_H` (= `DEFAULT_CELL_H` = 24).
- `Controller.viewportBottom()`: explicit accessor for the grid viewport's bottom edge (`CANVAS_H - STATUS_BAR_H - INFO_BAR_H` = 548).
- `Controller.reset()`: the `CANVAS_H-3*DEFAULT_CELL_H-4`-style arithmetic is rewritten in terms of the new constants — every computed value is identical to before.
- `EditorOperations.scrollCursorIntoView` and `ViewportSyncUiTest` read `viewportBottom()` instead of `statusBar.getY()`.

## Verification

- `./gradlew test` passes headless (TestFX + Monocle), including `ViewportSyncUiTest.cursorSitsFlushAtEdgesAfterScroll`, which directly exercises the changed scroll clamp.
- No behavior change intended; all geometry values are arithmetically unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)