### PR TITLE
Move bottom chrome to the scene graph

### DIFF
--- a/src/main/java/vimicalc/controller/Controller.java
+++ b/src/main/java/vimicalc/controller/Controller.java
@@ -4,7 +4,9 @@ import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
 import javafx.scene.canvas.Canvas;
 import javafx.scene.canvas.GraphicsContext;
+import javafx.scene.control.Label;
 import javafx.scene.input.KeyEvent;
+import javafx.scene.layout.StackPane;
 import javafx.scene.paint.Color;
 import org.jetbrains.annotations.NotNull;
 import vimicalc.model.*;
@@ -52,6 +54,17 @@ public class Controller implements Initializable {
     GraphicsContext gc;
     @FXML
     private Canvas canvas;
+    /** Overlay host for keystroke indicator / help menu (parts 3–4 of chrome migration). */
+    @FXML
+    private StackPane canvasStack;
+    @FXML
+    private Label statusLabel;
+    @FXML
+    private Label coordsLabel;
+    @FXML
+    private Label infoLabel;
+    @FXML
+    private Label exprLabel;
     /** Stack of cell states recorded before each edit, used for undo. */
     LinkedList<Cell> recordedCellStates;
     /** Stack of cell states produced by undo, used for redo. */
@@ -90,6 +103,11 @@ public class Controller implements Initializable {
     HashMap<Character, LinkedList<KeyEvent>> macros;
     /** Handles movement, navigation, editing, and undo/redo operations. */
     EditorOperations editorOps;
+    /**
+     * Whether a colon-command is being entered from VISUAL mode (via {@code ;}).
+     * Controller flow state — not part of the info-bar view.
+     */
+    boolean enteringCommandInVISUAL;
 
     /*CD arranger avec les classes moves car sinon cause des bugs en utilisant clavier
     public void onMouseClicked(@NotNull MouseEvent mouseEvent) {
@@ -149,7 +167,6 @@ public class Controller implements Initializable {
                     cellSelector.draw(gc);
                     helpMenu.navigate(event);
                     infoBar.setInfobarTxt(helpMenu.percentage());
-                    infoBar.draw(gc);
                     if (event.getCode() == ESCAPE) {
                         camera.ready();
                         camera.picture.resend(gc, camera.getAbsX(), camera.getAbsY());
@@ -206,9 +223,9 @@ public class Controller implements Initializable {
     private void commandInput(@NotNull KeyEvent event) {
         switch (event.getCode()) {
             case ESCAPE -> {
-                if (infoBar.isEnteringCommandInVISUAL()) {
+                if (enteringCommandInVISUAL) {
                     selectedCoords = new ArrayList<>();
-                    infoBar.setEnteringCommandInVISUAL(false);
+                    enteringCommandInVISUAL = false;
                 }
                 currMode = Mode.NORMAL;
                 command = new Command("", cellSelector.getXCoord(), cellSelector.getYCoord());
@@ -222,20 +239,18 @@ public class Controller implements Initializable {
                         command.interpret(sheet);
                     } catch (Exception e) {
                         infoBar.setInfobarTxt(e.getMessage());
-                        infoBar.draw(gc);
                     }
                     if (command.getCommandResult() == CommandResult.HELP) {
                         infoBar.setInfobarTxt(helpMenu.percentage());
-                        infoBar.draw(gc);
                         currMode = Mode.HELP;
                     }
                     onKeyPressed(event);
                     return;
                 }
-                if (infoBar.isEnteringCommandInVISUAL()) {
+                if (enteringCommandInVISUAL) {
                     try {
                         selectedCoords = new ArrayList<>();
-                        infoBar.setEnteringCommandInVISUAL(false);
+                        enteringCommandInVISUAL = false;
 
                         StringBuilder destinationCoord = new StringBuilder();
                         int i;
@@ -288,7 +303,6 @@ public class Controller implements Initializable {
                 cellSelector.readCell(camera.picture.data());
                 goTo(prevXC, prevYC);
                 if (commandError != null) infoBar.setInfobarTxt(commandError);
-                infoBar.draw(gc);
                 command = new Command("", cellSelector.getXCoord(), cellSelector.getYCoord());
             }
             case BACK_SPACE -> {
@@ -327,7 +341,7 @@ public class Controller implements Initializable {
                 onKeyPressed(event);
         }
 
-        if (infoBar.isEnteringCommandInVISUAL()) {
+        if (enteringCommandInVISUAL) {
             commandInput(event);
             return;
         }
@@ -411,7 +425,7 @@ public class Controller implements Initializable {
             }
             case SEMICOLON -> {
                 goingToMergeStart = false;
-                infoBar.setEnteringCommandInVISUAL(true);
+                enteringCommandInVISUAL = true;
                 infoBar.setCommandTxt(command.getTxt());
                 command = new Command("", cellSelector.getXCoord(), cellSelector.getYCoord());
             }
@@ -773,6 +787,9 @@ public class Controller implements Initializable {
         gc = canvas.getGraphicsContext2D();
         CANVAS_W = (int) canvas.getWidth();
         CANVAS_H = (int) canvas.getHeight();
+        statusBar = new StatusBar(statusLabel, () -> currMode);
+        infoBar = new InfoBar(infoLabel, exprLabel);
+        coordsInfo = new CoordsInfo(coordsLabel);
         sheet = new Sheet();
         sheet.setPositions(new Positions(
             CANVAS_W - GUTTER_W,
@@ -806,7 +823,6 @@ public class Controller implements Initializable {
                 if (e.getMessage().equals("New file")) {
                     updateVisualState();
                     infoBar.setInfobarTxt("New file");
-                    infoBar.draw(gc);
                 }
                 else infoBar.setInfobarTxt(e.getMessage());
             }
@@ -814,13 +830,13 @@ public class Controller implements Initializable {
     }
 
     /**
-     * Returns the y coordinate of the bottom edge of the grid viewport, i.e.
-     * where the sheet's drawable area ends and the status bar begins.
+     * Returns the y coordinate of the bottom edge of the grid viewport.
+     * With bottom chrome on the scene graph, this is the canvas height.
      *
      * @return the grid viewport's bottom edge, in canvas pixels
      */
     int viewportBottom() {
-        return CANVAS_H - STATUS_BAR_H - INFO_BAR_H;
+        return CANVAS_H;
     }
 
     /**
@@ -862,11 +878,6 @@ public class Controller implements Initializable {
             sheet.getCellsFormatting(),
             () -> currMode
         );
-        coordsInfo = new CoordsInfo(
-            CANVAS_W,
-            viewportBottom(),
-            STATUS_BAR_H
-        );
         firstCol = new FirstCol(
             0,
             HEADER_H,
@@ -885,21 +896,6 @@ public class Controller implements Initializable {
             camera,
             camera.picture.metadata()
         );
-        infoBar = new InfoBar(
-            0,
-            CANVAS_H-INFO_BAR_H,
-            CANVAS_W,
-            INFO_BAR_H,
-            DEFAULT_CELL_C
-        );
-        statusBar = new StatusBar(
-            0,
-            viewportBottom(),
-            CANVAS_W,
-            STATUS_BAR_H,
-            Color.LIGHTGREEN,
-            () -> currMode
-        );
         keyStrokeCell = new KeyStrokeCell(
             0,
             0,
@@ -909,6 +905,7 @@ public class Controller implements Initializable {
         );
 
         currMode = Mode.NORMAL;
+        enteringCommandInVISUAL = false;
         editorOps = new EditorOperations(this);
         keyCommand = new KeyCommand(editorOps, this);
         command = new Command("", cellSelector.getXCoord(), cellSelector.getYCoord());
@@ -923,13 +920,13 @@ public class Controller implements Initializable {
         keyStrokeCell.draw(gc);
         firstCol.draw(gc);
         firstRow.draw(gc);
-        statusBar.draw(gc);
+        statusBar.setFilename("new_file");
+        statusBar.refresh();
         coordsInfo.setCoords(cellSelector.getXCoord(), cellSelector.getYCoord());
-        coordsInfo.draw(gc);
         cellSelector.readCell(camera.picture.data());
         cellSelector.draw(gc);
+        infoBar.setIBarExpr("");
         infoBar.setInfobarTxt(cellSelector.getSelectedCell().txt());
-        infoBar.draw(gc);
         sheet.setPositions(camera.picture.metadata());
     }
 }

--- a/src/main/java/vimicalc/controller/EditorOperations.java
+++ b/src/main/java/vimicalc/controller/EditorOperations.java
@@ -359,13 +359,11 @@ public class EditorOperations {
         if (ctrl.undoCounter != 0) removeUltCStates();
     }
 
-    /** Redraws all chrome UI elements (headers, status bar, info bar, coordinates). */
+    /** Redraws canvas headers and refreshes the status-bar label (mode/filename). */
     public void updateVisualState() {
         ctrl.firstCol.draw(ctrl.gc);
         ctrl.firstRow.draw(ctrl.gc);
-        ctrl.statusBar.draw(ctrl.gc);
-        ctrl.infoBar.draw(ctrl.gc);
-        ctrl.coordsInfo.draw(ctrl.gc);
+        ctrl.statusBar.refresh();
     }
 
     /** Prepares the selected cell's text for INSERT mode editing. */

--- a/src/main/java/vimicalc/controller/KeyCommand.java
+++ b/src/main/java/vimicalc/controller/KeyCommand.java
@@ -145,7 +145,6 @@ public class KeyCommand {
         if (c != 0) expr += c;
         if (canChangeIBarExpr) {
             ctrl.infoBar.setIBarExpr(expr);
-            ctrl.infoBar.draw(ctrl.gc);
         }
         evaluate(expr);
     }

--- a/src/main/java/vimicalc/view/CoordsInfo.java
+++ b/src/main/java/vimicalc/view/CoordsInfo.java
@@ -1,10 +1,6 @@
 package vimicalc.view;
 
-import javafx.geometry.VPos;
-import javafx.scene.canvas.GraphicsContext;
-import javafx.scene.paint.Color;
-import javafx.scene.text.TextAlignment;
-import org.jetbrains.annotations.NotNull;
+import javafx.scene.control.Label;
 
 import static vimicalc.utils.Conversions.toAlpha;
 
@@ -13,24 +9,21 @@ import static vimicalc.utils.Conversions.toAlpha;
  * (e.g. "A1:C4") in the status area of the spreadsheet.
  *
  * <p>In NORMAL mode it shows a single cell reference; in VISUAL mode it
- * shows the bounding range of the selection.</p>
+ * shows the bounding range of the selection. The string field is the source
+ * of truth and is mirrored to a scene-graph {@link Label}.</p>
  */
 public class CoordsInfo {
-    int x, y, h;
-
+    private final Label coordsLabel;
     private String coords;
 
     /**
-     * Creates a coordinate display at the given position.
+     * Creates a coordinate display bound to the given label.
      *
-     * @param x the x pixel position (right edge)
-     * @param y the y pixel position
-     * @param h the height in pixels
+     * @param coordsLabel the scene-graph label to update
      */
-    public CoordsInfo(int x, int y, int h) {
-        this.x = x;
-        this.y = y;
-        this.h = h;
+    public CoordsInfo(Label coordsLabel) {
+        this.coordsLabel = coordsLabel;
+        coords = "";
     }
 
     /**
@@ -41,6 +34,7 @@ public class CoordsInfo {
      */
     public void setCoords(int xCoord, int yCoord) {
         coords = toAlpha(xCoord-1) + yCoord;
+        coordsLabel.setText(coords);
     }
 
     /**
@@ -53,6 +47,7 @@ public class CoordsInfo {
      */
     public void setCoords(int maxXC, int minXC, int maxYC, int minYC) {
         coords = toAlpha(minXC-1) + minYC + ":" + toAlpha(maxXC-1) + maxYC;
+        coordsLabel.setText(coords);
     }
 
     /**
@@ -62,17 +57,5 @@ public class CoordsInfo {
      */
     public String getCoords() {
         return coords;
-    }
-
-    /**
-     * Draws the coordinate display onto the canvas.
-     *
-     * @param gc the graphics context
-     */
-    public void draw(@NotNull GraphicsContext gc) {
-        gc.setFill(Color.BLUE);
-        gc.setTextAlign(TextAlignment.RIGHT);
-        gc.setTextBaseline(VPos.CENTER);
-        gc.fillText(coords, x-4, y + (float)h/2);
     }
 }

--- a/src/main/java/vimicalc/view/InfoBar.java
+++ b/src/main/java/vimicalc/view/InfoBar.java
@@ -1,10 +1,6 @@
 package vimicalc.view;
 
-import javafx.geometry.VPos;
-import javafx.scene.canvas.GraphicsContext;
-import javafx.scene.paint.Color;
-import javafx.scene.text.TextAlignment;
-import org.jetbrains.annotations.NotNull;
+import javafx.scene.control.Label;
 
 import java.util.Objects;
 
@@ -20,27 +16,29 @@ import java.util.Objects;
  * </ul>
  *
  * <p>The field {@link #iBarExpr} holds the current key-command expression
- * displayed on the right side of the bar.</p>
+ * displayed on the right side of the bar. Both sides are scene-graph labels;
+ * setters update the labels immediately.</p>
  */
-public class InfoBar extends simpleRect {
+public class InfoBar {
+
+    private final Label infoLabel;
+    private final Label exprLabel;
 
     /** The current key-command expression, displayed right-aligned in the info bar. */
     private String iBarExpr;
     private String infobarTxt;
-    private boolean enteringCommandInVISUAL;
 
     /**
-     * Creates the info bar at the given position.
+     * Creates the info bar bound to the given labels.
      *
-     * @param x the x pixel position
-     * @param y the y pixel position
-     * @param w the width in pixels
-     * @param h the height in pixels
-     * @param c the background color
+     * @param infoLabel the left-side contextual text label
+     * @param exprLabel the right-side key-command expression label
      */
-    public InfoBar(int x, int y, int w, int h, Color c) {
-        super(x, y, w, h, c);
+    public InfoBar(Label infoLabel, Label exprLabel) {
+        this.infoLabel = infoLabel;
+        this.exprLabel = exprLabel;
         iBarExpr = "";
+        infobarTxt = "(=I)";
     }
 
     /**
@@ -59,24 +57,7 @@ public class InfoBar extends simpleRect {
      */
     public void setIBarExpr(String iBarExpr) {
         this.iBarExpr = iBarExpr;
-    }
-
-    /**
-     * Returns whether a command is being entered in VISUAL mode.
-     *
-     * @return {@code true} if entering a command in VISUAL mode
-     */
-    public boolean isEnteringCommandInVISUAL() {
-        return enteringCommandInVISUAL;
-    }
-
-    /**
-     * Sets whether a command is being entered in VISUAL mode.
-     *
-     * @param enteringCommandInVISUAL the flag
-     */
-    public void setEnteringCommandInVISUAL(boolean enteringCommandInVISUAL) {
-        this.enteringCommandInVISUAL = enteringCommandInVISUAL;
+        exprLabel.setText(iBarExpr);
     }
 
     /**
@@ -86,6 +67,7 @@ public class InfoBar extends simpleRect {
      */
     public void setCommandTxt(String infobarTxt) {
         this.infobarTxt = ":" + infobarTxt;
+        infoLabel.setText(this.infobarTxt);
     }
 
     /**
@@ -95,6 +77,7 @@ public class InfoBar extends simpleRect {
      */
     public void setEnteringFormula(String infobarTxt) {
         this.infobarTxt = "% " + infobarTxt.replace(".0" , "");
+        infoLabel.setText(this.infobarTxt);
     }
 
     /**
@@ -104,6 +87,7 @@ public class InfoBar extends simpleRect {
      */
     public void setInfobarTxt(String infobarTxt) {
         this.infobarTxt = Objects.requireNonNullElse(infobarTxt, "(=I)");
+        infoLabel.setText(this.infobarTxt);
     }
 
     /**
@@ -113,16 +97,5 @@ public class InfoBar extends simpleRect {
      */
     public String getInfobarTxt() {
         return infobarTxt;
-    }
-
-    @Override
-    public void draw(@NotNull GraphicsContext gc) {
-        super.draw(gc);
-        gc.setFill(Color.BLACK);
-        gc.setTextBaseline(VPos.CENTER);
-        gc.setTextAlign(TextAlignment.RIGHT);
-        gc.fillText(iBarExpr, x + w - 4, y + (float)h/2);
-        gc.setTextAlign(TextAlignment.LEFT);
-        gc.fillText(infobarTxt,2, y + (float)h/2);
     }
 }

--- a/src/main/java/vimicalc/view/StatusBar.java
+++ b/src/main/java/vimicalc/view/StatusBar.java
@@ -1,10 +1,6 @@
 package vimicalc.view;
 
-import javafx.geometry.VPos;
-import javafx.scene.canvas.GraphicsContext;
-import javafx.scene.paint.Color;
-import javafx.scene.text.TextAlignment;
-import org.jetbrains.annotations.NotNull;
+import javafx.scene.control.Label;
 import vimicalc.controller.Mode;
 
 import java.util.function.Supplier;
@@ -13,35 +9,33 @@ import java.util.function.Supplier;
  * The status bar displayed near the bottom of the window.
  *
  * <p>Shows the current editing {@link vimicalc.controller.Mode} and the
- * name of the open file (or "new_file" if unsaved).</p>
+ * name of the open file (or "new_file" if unsaved). Backed by a scene-graph
+ * {@link Label}; call {@link #refresh()} after mode or filename changes.</p>
  */
-public class StatusBar extends simpleRect {
+public class StatusBar {
+    private final Label statusLabel;
     private String filename;
     private final Supplier<Mode> modeSupplier;
 
     /**
-     * Creates the status bar.
+     * Creates the status bar bound to the given label.
      *
-     * @param x            the x pixel position
-     * @param y            the y pixel position
-     * @param w            the width in pixels
-     * @param h            the height in pixels
-     * @param c            the background color
+     * @param statusLabel  the scene-graph label to update
      * @param modeSupplier supplies the current editing mode
      */
-    public StatusBar(int x, int y, int w, int h, Color c, Supplier<Mode> modeSupplier) {
-        super(x, y, w, h, c);
+    public StatusBar(Label statusLabel, Supplier<Mode> modeSupplier) {
+        this.statusLabel = statusLabel;
         this.modeSupplier = modeSupplier;
         filename = "new_file";
     }
 
-    @Override
-    public void draw(@NotNull GraphicsContext gc) {
-        super.draw(gc);
-        gc.setFill(Color.BLUE);
-        gc.setTextBaseline(VPos.CENTER);
-        gc.setTextAlign(TextAlignment.LEFT);
-        gc.fillText(" [" + modeSupplier.get() + "]  --" + filename + "--", 2, y + (float)h/2);
+    /**
+     * Updates the label text to reflect the current mode and filename.
+     *
+     * <p>Format: {@code  [MODE]  --filename--}</p>
+     */
+    public void refresh() {
+        statusLabel.setText(" [" + modeSupplier.get() + "]  --" + filename + "--");
     }
 
     /** @param filename the name of the open file */

--- a/src/main/resources/vimicalc/GUI.fxml
+++ b/src/main/resources/vimicalc/GUI.fxml
@@ -1,47 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--
-  Copyright (c) 2015, 2019, Gluon and/or its affiliates.
-  All rights reserved. Use is subject to license terms.
-
-  This file is available and licensed under the following license:
-
-  Redistribution and use in source and binary forms, with or without
-  modification, are permitted provided that the following conditions
-  are met:
-
-  - Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-  - Redistributions in binary shape must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in
-    the documentation and/or other materials provided with the distribution.
-  - Neither the name of Oracle Corporation nor the names of its
-    contributors may be used to endorse or promote products derived
-    from this software without specific prior written permission.
-
-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
--->
-
 <?import javafx.scene.canvas.Canvas?>
-<?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Region?>
+<?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 
-<VBox prefHeight="600.0" prefWidth="900.0" xmlns="http://javafx.com/javafx/20.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="vimicalc.controller.Controller">
+<VBox prefHeight="600.0" prefWidth="900.0" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1" fx:controller="vimicalc.controller.Controller">
   <children>
-    <AnchorPane maxHeight="-1.0" maxWidth="-1.0" prefHeight="-1.0" prefWidth="-1.0" VBox.vgrow="ALWAYS">
-         <children>
-            <Canvas fx:id="canvas" height="600.0" width="900.0" />
-         </children>
-    </AnchorPane>
+    <StackPane fx:id="canvasStack" prefHeight="548.0" prefWidth="900.0">
+      <children>
+        <Canvas fx:id="canvas" height="548.0" width="900.0" />
+      </children>
+    </StackPane>
+    <HBox fx:id="statusRow" alignment="CENTER_LEFT" prefHeight="28.0" prefWidth="900.0" style="-fx-background-color: lightgreen;">
+      <children>
+        <Label fx:id="statusLabel" focusTraversable="false" style="-fx-text-fill: blue;" text=" [NORMAL]  --new_file--" />
+        <Region HBox.hgrow="ALWAYS" />
+        <Label fx:id="coordsLabel" focusTraversable="false" style="-fx-text-fill: blue; -fx-padding: 0 4 0 0;" text="B2" />
+      </children>
+    </HBox>
+    <HBox fx:id="infoRow" alignment="CENTER_LEFT" prefHeight="24.0" prefWidth="900.0" style="-fx-background-color: white;">
+      <children>
+        <Label fx:id="infoLabel" focusTraversable="false" text="(=I)" />
+        <Region HBox.hgrow="ALWAYS" />
+        <Label fx:id="exprLabel" focusTraversable="false" style="-fx-padding: 0 4 0 0;" text="" />
+      </children>
+    </HBox>
   </children>
 </VBox>

--- a/src/test/java/vimicalc/controller/ChromeLabelsUiTest.java
+++ b/src/test/java/vimicalc/controller/ChromeLabelsUiTest.java
@@ -1,0 +1,131 @@
+package vimicalc.controller;
+
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Parent;
+import javafx.scene.Scene;
+import javafx.scene.control.Label;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
+import javafx.stage.Stage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.api.FxRobot;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+import vimicalc.Main;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * TestFX checks that bottom-chrome Labels track app state after the scene-graph
+ * migration (issue #43). Labels are queryable via {@code fx:id} without pixel reads.
+ *
+ * <p>Key events are delivered by calling {@link Controller#onKeyPressed} with
+ * synthetic events rather than OS-level key injection, so the suite stays reliable
+ * without a focused display window.</p>
+ */
+@ExtendWith(ApplicationExtension.class)
+class ChromeLabelsUiTest {
+
+    private Controller controller;
+    private Parent root;
+
+    @Start
+    void start(Stage stage) throws Exception {
+        FXMLLoader loader = new FXMLLoader(Main.class.getResource("GUI.fxml"));
+        root = loader.load();
+        controller = loader.getController();
+        Scene scene = new Scene(root, 900, 600);
+        scene.setOnKeyPressed(controller::onKeyPressed);
+        stage.setScene(scene);
+        stage.show();
+    }
+
+    private Label label(String fxId) {
+        return (Label) root.lookup(fxId);
+    }
+
+    /** Delivers a KEY_PRESSED event to the controller on the JavaFX thread. */
+    private void press(FxRobot robot, KeyCode code, String text) {
+        KeyEvent event = new KeyEvent(
+            KeyEvent.KEY_PRESSED, text, text, code,
+            false, false, false, false
+        );
+        robot.interact(() -> controller.onKeyPressed(event));
+    }
+
+    private void press(FxRobot robot, KeyCode code) {
+        String text = code.isLetterKey() || code.isDigitKey()
+            ? code.getName().toLowerCase()
+            : "";
+        if (code == KeyCode.DIGIT5) text = "5";
+        if (code == KeyCode.SEMICOLON) text = ";";
+        if (code == KeyCode.V) text = "v";
+        if (code == KeyCode.J) text = "j";
+        if (code == KeyCode.W) text = "w";
+        press(robot, code, text);
+    }
+
+    @Test
+    void initialChromeLabelsMatchStartupState() {
+        Label status = label("#statusLabel");
+        Label coords = label("#coordsLabel");
+        Label info = label("#infoLabel");
+
+        assertTrue(status.getText().contains("[NORMAL]"),
+            "status bar should show NORMAL mode on startup: " + status.getText());
+        assertTrue(status.getText().contains("new_file"),
+            "status bar should show default filename: " + status.getText());
+        assertEquals("B2", coords.getText(),
+            "coords should start at B2");
+        assertEquals("(=I)", info.getText(),
+            "empty cell shows default info placeholder");
+    }
+
+    @Test
+    void statusLabelTracksVisualMode(FxRobot robot) {
+        press(robot, KeyCode.V);
+        assertEquals(Mode.VISUAL, controller.currMode);
+
+        Label status = label("#statusLabel");
+        assertTrue(status.getText().contains("[VISUAL]"),
+            "status bar should show VISUAL after v: " + status.getText());
+    }
+
+    @Test
+    void infoLabelEchoesColonCommand(FxRobot robot) {
+        // App uses ';' for command mode (not ':')
+        press(robot, KeyCode.SEMICOLON);
+        assertEquals(Mode.COMMAND, controller.currMode);
+
+        press(robot, KeyCode.W);
+        Label info = label("#infoLabel");
+        assertTrue(info.getText().startsWith(":"),
+            "command mode should prefix with ':': " + info.getText());
+        assertTrue(info.getText().contains("w"),
+            "typed command characters should appear in infoLabel: " + info.getText());
+    }
+
+    @Test
+    void coordsLabelUpdatesOnMove(FxRobot robot) {
+        press(robot, KeyCode.J);
+        Label coords = label("#coordsLabel");
+        assertEquals("B3", coords.getText(),
+            "moving down from B2 should show B3");
+    }
+
+    @Test
+    void exprLabelShowsPendingKeyCommand(FxRobot robot) {
+        press(robot, KeyCode.DIGIT5);
+        Label expr = label("#exprLabel");
+        assertEquals("5", expr.getText(),
+            "pending multiplier should appear on exprLabel while typing a key command");
+    }
+
+    @Test
+    void canvasIsGridOnlyHeight() {
+        assertEquals(900, controller.CANVAS_W);
+        assertEquals(548, controller.viewportBottom(),
+            "viewport bottom equals canvas height after chrome leaves the canvas");
+    }
+}


### PR DESCRIPTION
Closes #43. Part 2 of the canvas→FXML chrome migration (#42 → **#43** → #44 → #45; follow-up #46).

## What

The canvas is now grid-only (900×548). Status bar, coords display, and info bar are real scene-graph `Label`s declared in `GUI.fxml`.

- **`GUI.fxml`**: VBox with `canvasStack` (Canvas 900×548) + status row (28px, lightgreen) + info row (24px). Drops the stale Gluon license header.
- **`StatusBar` / `InfoBar` / `CoordsInfo`**: thin Label-backed wrappers. Setters update labels immediately (except status mode/filename via `refresh()`). Drop canvas `draw` and `simpleRect`.
- **`Controller`**: `@FXML` labels; wrappers constructed once in `initialize()`; `reset()` only resets content. `enteringCommandInVISUAL` moved off `InfoBar` onto the controller. `viewportBottom()` → `CANVAS_H` (still 548). Positions picture height 576 → 524.
- **`EditorOperations.updateVisualState`**: headers + `statusBar.refresh()` only.
- **`ChromeLabelsUiTest`**: asserts label text tracks mode, coords, command echo, and pending key expr.

## Verification

- `./gradlew clean test` — full suite green, including new `ChromeLabelsUiTest` and existing `ViewportSyncUiTest`.
- Manual (when a display is available): mode/filename on `:w`; coords NORMAL + range VISUAL; `:` / `%` echo; pending expr while typing `5j`; scroll clamp flush at bottom edge.


🤖 Generated with Grok Build
