### PR TITLE
Move KeyStrokeCell to FXML overlay Label

### DIFF
--- a/src/main/java/vimicalc/controller/Controller.java
+++ b/src/main/java/vimicalc/controller/Controller.java
@@ -6,6 +6,7 @@ import javafx.scene.canvas.Canvas;
 import javafx.scene.canvas.GraphicsContext;
 import javafx.scene.control.Label;
 import javafx.scene.input.KeyEvent;
+import javafx.scene.layout.Pane;
 import javafx.scene.layout.StackPane;
 import javafx.scene.paint.Color;
 import org.jetbrains.annotations.NotNull;
@@ -57,6 +58,14 @@ public class Controller implements Initializable {
     /** Overlay host for keystroke indicator / help menu (parts 3–4 of chrome migration). */
     @FXML
     private StackPane canvasStack;
+    /**
+     * Absolute-positioned overlay on the canvas stack. Hosts the keystroke
+     * label now; part 4 (#45) will also place the help node here.
+     */
+    @FXML
+    private Pane overlayPane;
+    @FXML
+    private Label keyStrokeLabel;
     @FXML
     private Label statusLabel;
     @FXML
@@ -206,7 +215,6 @@ public class Controller implements Initializable {
             System.out.println('}');
         }
         if (currMode != Mode.HELP) updateVisualState();
-        keyStrokeCell.draw(gc);
     }
 
     /** Redraws all chrome UI elements. Delegates to {@link EditorOperations}. */
@@ -790,6 +798,7 @@ public class Controller implements Initializable {
         statusBar = new StatusBar(statusLabel, () -> currMode);
         infoBar = new InfoBar(infoLabel, exprLabel);
         coordsInfo = new CoordsInfo(coordsLabel);
+        keyStrokeCell = new KeyStrokeCell(keyStrokeLabel);
         sheet = new Sheet();
         sheet.setPositions(new Positions(
             CANVAS_W - GUTTER_W,
@@ -896,13 +905,6 @@ public class Controller implements Initializable {
             camera,
             camera.picture.metadata()
         );
-        keyStrokeCell = new KeyStrokeCell(
-            0,
-            0,
-            DEFAULT_CELL_W/2,
-            DEFAULT_CELL_H,
-            Color.LIGHTGREEN
-        );
 
         currMode = Mode.NORMAL;
         enteringCommandInVISUAL = false;
@@ -917,7 +919,7 @@ public class Controller implements Initializable {
         clipboard = new ArrayList<>();
 
         camera.ready();
-        keyStrokeCell.draw(gc);
+        keyStrokeCell.setKeyStroke("");
         firstCol.draw(gc);
         firstRow.draw(gc);
         statusBar.setFilename("new_file");

--- a/src/main/java/vimicalc/view/KeyStrokeCell.java
+++ b/src/main/java/vimicalc/view/KeyStrokeCell.java
@@ -1,32 +1,26 @@
 package vimicalc.view;
 
-import javafx.geometry.VPos;
-import javafx.scene.canvas.GraphicsContext;
-import javafx.scene.paint.Color;
-import javafx.scene.text.TextAlignment;
-import org.jetbrains.annotations.NotNull;
+import javafx.scene.control.Label;
 
 /**
  * A small UI cell in the top-left corner that displays the name of the
  * last key pressed.
  *
  * <p>Provides visual feedback so the user can see which key event was
- * registered, useful when building multi-key commands.</p>
+ * registered, useful when building multi-key commands. Backed by a
+ * scene-graph {@link Label}; {@link #setKeyStroke(String)} updates the
+ * label immediately.</p>
  */
-public class KeyStrokeCell extends simpleRect {
-    private String keyStroke;
+public class KeyStrokeCell {
+    private final Label keyStrokeLabel;
+
     /**
-     * Creates a keystroke display cell.
+     * Creates a keystroke display bound to the given label.
      *
-     * @param x the x pixel position
-     * @param y the y pixel position
-     * @param w the width in pixels
-     * @param h the height in pixels
-     * @param c the background color
+     * @param keyStrokeLabel the scene-graph label to update
      */
-    public KeyStrokeCell(int x, int y, int w, int h, Color c) {
-        super(x, y, w, h, c);
-        keyStroke = "";
+    public KeyStrokeCell(Label keyStrokeLabel) {
+        this.keyStrokeLabel = keyStrokeLabel;
     }
 
     /**
@@ -35,15 +29,6 @@ public class KeyStrokeCell extends simpleRect {
      * @param keyStroke the key name
      */
     public void setKeyStroke(String keyStroke) {
-        this.keyStroke = keyStroke;
-    }
-
-    @Override
-    public void draw(@NotNull GraphicsContext gc) {
-        super.draw(gc);
-        gc.setFill(Color.BLUE);
-        gc.setTextAlign(TextAlignment.CENTER);
-        gc.setTextBaseline(VPos.CENTER);
-        gc.fillText(keyStroke, (float) w/2, (float) h/2, w);
+        keyStrokeLabel.setText(keyStroke);
     }
 }

--- a/src/main/resources/vimicalc/GUI.fxml
+++ b/src/main/resources/vimicalc/GUI.fxml
@@ -3,6 +3,7 @@
 <?import javafx.scene.canvas.Canvas?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Pane?>
 <?import javafx.scene.layout.Region?>
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
@@ -12,6 +13,11 @@
     <StackPane fx:id="canvasStack" prefHeight="548.0" prefWidth="900.0">
       <children>
         <Canvas fx:id="canvas" height="548.0" width="900.0" />
+        <Pane fx:id="overlayPane" mouseTransparent="true" pickOnBounds="false" prefHeight="548.0" prefWidth="900.0">
+          <children>
+            <Label fx:id="keyStrokeLabel" alignment="CENTER" focusTraversable="false" layoutX="0.0" layoutY="0.0" prefHeight="24.0" prefWidth="48.0" style="-fx-background-color: lightgreen; -fx-text-fill: blue;" text="" />
+          </children>
+        </Pane>
       </children>
     </StackPane>
     <HBox fx:id="statusRow" alignment="CENTER_LEFT" prefHeight="28.0" prefWidth="900.0" style="-fx-background-color: lightgreen;">

--- a/src/test/java/vimicalc/controller/ChromeLabelsUiTest.java
+++ b/src/test/java/vimicalc/controller/ChromeLabelsUiTest.java
@@ -71,6 +71,7 @@ class ChromeLabelsUiTest {
         Label status = label("#statusLabel");
         Label coords = label("#coordsLabel");
         Label info = label("#infoLabel");
+        Label keyStroke = label("#keyStrokeLabel");
 
         assertTrue(status.getText().contains("[NORMAL]"),
             "status bar should show NORMAL mode on startup: " + status.getText());
@@ -80,6 +81,21 @@ class ChromeLabelsUiTest {
             "coords should start at B2");
         assertEquals("(=I)", info.getText(),
             "empty cell shows default info placeholder");
+        assertNotNull(keyStroke, "keystroke overlay label must be present");
+        assertEquals("", keyStroke.getText(),
+            "keystroke label starts empty before any key");
+    }
+
+    @Test
+    void keyStrokeLabelTracksLastKeyPressed(FxRobot robot) {
+        press(robot, KeyCode.J);
+        Label keyStroke = label("#keyStrokeLabel");
+        assertEquals("J", keyStroke.getText(),
+            "keystroke label should show KeyCode name after j");
+
+        press(robot, KeyCode.V);
+        assertEquals("V", keyStroke.getText(),
+            "keystroke label should update to the latest key");
     }
 
     @Test


### PR DESCRIPTION
Closes #44. Part 3 of the canvas→FXML chrome migration (#42 → #43 → **#44** → #45; follow-up #46).

## What

The last-key indicator leaves the canvas and becomes a scene-graph `Label` in the top-left corner.

- **`GUI.fxml`**: inside `canvasStack`, add `Pane overlayPane` (`mouseTransparent`, `pickOnBounds=false`) hosting `Label keyStrokeLabel` at (0,0), pref 48×24, lightgreen background, blue centered text. `overlayPane` is prepared for part 4 (#45) help host.
- **`KeyStrokeCell`**: thin `Label`-backed wrapper; `setKeyStroke` → `setText`. Drop `simpleRect` and `draw`.
- **`Controller`**: `@FXML` `keyStrokeLabel` / `overlayPane`; construct `KeyStrokeCell` once in `initialize()`; `reset()` only clears text. Remove both `keyStrokeCell.draw(gc)` call sites (`onKeyPressed`, `reset()`).
- **`ChromeLabelsUiTest`**: assert empty keystroke label at startup and that it tracks `KeyCode` names after key events.

Nothing else paints the (0,0,48,24) corner (`FirstRow` at x=48, `FirstCol` at y=24); the opaque Label covers the unpainted canvas corner.

## Verification

- On **kubuntu** with Xvfb: `xvfb-run -a ./gradlew --no-daemon clean test` — **BUILD SUCCESSFUL** (full suite, including new keystroke assertions).
- Manual (when a display is available): every keypress updates the corner indicator; no grid bleed-through after scroll/zoom.


🤖 Generated with Grok Build
