### PR TITLE
Move HelpMenu to FXML overlay Label

### DIFF
--- a/src/main/java/vimicalc/controller/Controller.java
+++ b/src/main/java/vimicalc/controller/Controller.java
@@ -60,12 +60,14 @@ public class Controller implements Initializable {
     private StackPane canvasStack;
     /**
      * Absolute-positioned overlay on the canvas stack. Hosts the keystroke
-     * label now; part 4 (#45) will also place the help node here.
+     * label and the help menu node.
      */
     @FXML
     private Pane overlayPane;
     @FXML
     private Label keyStrokeLabel;
+    @FXML
+    private Label helpLabel;
     @FXML
     private Label statusLabel;
     @FXML
@@ -170,19 +172,12 @@ public class Controller implements Initializable {
                 case COMMAND -> commandInput(event);
                 case FORMULA -> formulaInput(event);
                 case HELP -> {
-                    camera.picture.resend(gc, camera.getAbsX(), camera.getAbsY());
-                    updateVisualState();
-                    cellSelector.readCell(camera.picture.data());
-                    cellSelector.draw(gc);
                     helpMenu.navigate(event);
                     infoBar.setInfobarTxt(helpMenu.percentage());
                     if (event.getCode() == ESCAPE) {
-                        camera.ready();
-                        camera.picture.resend(gc, camera.getAbsX(), camera.getAbsY());
-                        cellSelector.readCell(camera.picture.data());
-                        cellSelector.draw(gc);
+                        helpMenu.hide();
+                        currMode = Mode.NORMAL;
                         cellContentToIBar();
-                        updateVisualState();
                     }
                 }
                 case INSERT -> textInput(event);
@@ -249,10 +244,12 @@ public class Controller implements Initializable {
                         infoBar.setInfobarTxt(e.getMessage());
                     }
                     if (command.getCommandResult() == CommandResult.HELP) {
-                        infoBar.setInfobarTxt(helpMenu.percentage());
                         currMode = Mode.HELP;
+                        helpMenu.show();
+                        infoBar.setInfobarTxt(helpMenu.percentage());
+                        statusBar.refresh();
                     }
-                    onKeyPressed(event);
+                    command = new Command("", cellSelector.getXCoord(), cellSelector.getYCoord());
                     return;
                 }
                 if (enteringCommandInVISUAL) {
@@ -799,6 +796,7 @@ public class Controller implements Initializable {
         infoBar = new InfoBar(infoLabel, exprLabel);
         coordsInfo = new CoordsInfo(coordsLabel);
         keyStrokeCell = new KeyStrokeCell(keyStrokeLabel);
+        helpMenu = new HelpMenu(helpLabel);
         sheet = new Sheet();
         sheet.setPositions(new Positions(
             CANVAS_W - GUTTER_W,
@@ -822,7 +820,6 @@ public class Controller implements Initializable {
             }
         });
         macros = new HashMap<>();
-        helpMenu = new HelpMenu(gc, mode -> currMode = mode);
         reset();
         if (arg1 != null) {
             try {

--- a/src/main/java/vimicalc/view/HelpMenu.java
+++ b/src/main/java/vimicalc/view/HelpMenu.java
@@ -1,15 +1,8 @@
 package vimicalc.view;
 
-import javafx.geometry.VPos;
-import javafx.scene.canvas.GraphicsContext;
+import javafx.scene.control.Label;
 import javafx.scene.input.KeyEvent;
-import javafx.scene.paint.Color;
-import javafx.scene.text.TextAlignment;
 import org.jetbrains.annotations.NotNull;
-
-import vimicalc.controller.Mode;
-
-import java.util.function.Consumer;
 
 /**
  * An overlay window that displays built-in help text when the user enters
@@ -17,12 +10,12 @@ import java.util.function.Consumer;
  *
  * <p>Supports scrolling with {@code j}/{@code k} keys and dismissal with
  * {@code ESC}. The text is a static array of lines covering modes,
- * key commands, macros, formulas, and conditional expressions.</p>
+ * key commands, macros, formulas, and conditional expressions. Backed by a
+ * scene-graph {@link Label}; the controller owns mode transitions.</p>
  */
-public class HelpMenu extends simpleRect {
+public class HelpMenu {
     private int position;
-    private final GraphicsContext gc;
-    private final Consumer<Mode> modeSetter;
+    private final Label helpLabel;
     private final String[] text = {
         "=====Overview of how WeSpreadSheet works=====",
         "\n",
@@ -89,22 +82,20 @@ public class HelpMenu extends simpleRect {
     };
 
     /**
-     * Creates the help menu overlay.
+     * Creates the help menu overlay bound to the given label.
      *
-     * @param gc         the graphics context for rendering
-     * @param modeSetter consumer to set the current editing mode
+     * @param helpLabel the scene-graph label to show help text on
      */
-    public HelpMenu(GraphicsContext gc, Consumer<Mode> modeSetter) {
-        super(30, 30, 740, 480, Color.LIGHTYELLOW);
-        this.gc = gc;
-        this.modeSetter = modeSetter;
+    public HelpMenu(Label helpLabel) {
+        this.helpLabel = helpLabel;
         position = 0;
     }
 
     /**
      * Handles keyboard input within the help menu.
-     * {@code J} scrolls down, {@code K} scrolls up, {@code ESC} closes the menu
-     * and returns to NORMAL mode.
+     * {@code J} scrolls down, {@code K} scrolls up, {@code ESC} only resets
+     * the scroll position — the controller flips the mode and calls
+     * {@link #hide()}.
      *
      * @param event the key event to process
      */
@@ -118,13 +109,26 @@ public class HelpMenu extends simpleRect {
                 System.out.println("Scrolling up...");
                 if (position > 0) position -= 1;
             }
-            case ESCAPE -> {
-                position = 0;
-                modeSetter.accept(Mode.NORMAL);
-            }
+            case ESCAPE -> position = 0;
             default -> {}
         }
-        drawText();
+        updateText();
+    }
+
+    /**
+     * Shows the help overlay at the top of the document.
+     */
+    public void show() {
+        position = 0;
+        updateText();
+        helpLabel.setVisible(true);
+    }
+
+    /**
+     * Hides the help overlay.
+     */
+    public void hide() {
+        helpLabel.setVisible(false);
     }
 
     /**
@@ -136,18 +140,14 @@ public class HelpMenu extends simpleRect {
         return (int) (100.0 * position / text.length) + "%";
     }
 
-    /** Renders the help text onto the canvas, showing up to 24 lines from the current scroll position. */
-    public void drawText() {
-        super.draw(gc);
-        gc.setFill(Color.BLACK);
-        gc.setTextBaseline(VPos.TOP);
-        gc.setTextAlign(TextAlignment.LEFT);
+    /** Updates the label to the 24-line slice starting at the current scroll position. */
+    private void updateText() {
         StringBuilder txt = new StringBuilder();
         for (int i = position; i < position + 24; i++) {
             if (i < text.length)
                 txt.append(text[i]).append('\n');
             else break;
         }
-        gc.fillText(txt.toString(), x+10, y+10);
+        helpLabel.setText(txt.toString());
     }
 }

--- a/src/main/resources/vimicalc/GUI.fxml
+++ b/src/main/resources/vimicalc/GUI.fxml
@@ -16,6 +16,7 @@
         <Pane fx:id="overlayPane" mouseTransparent="true" pickOnBounds="false" prefHeight="548.0" prefWidth="900.0">
           <children>
             <Label fx:id="keyStrokeLabel" alignment="CENTER" focusTraversable="false" layoutX="0.0" layoutY="0.0" prefHeight="24.0" prefWidth="48.0" style="-fx-background-color: lightgreen; -fx-text-fill: blue;" text="" />
+            <Label fx:id="helpLabel" alignment="TOP_LEFT" focusTraversable="false" layoutX="30.0" layoutY="30.0" mouseTransparent="true" prefHeight="480.0" prefWidth="740.0" style="-fx-background-color: lightyellow; -fx-text-fill: black; -fx-padding: 10;" text="" visible="false" wrapText="true" />
           </children>
         </Pane>
       </children>

--- a/src/test/java/vimicalc/controller/HelpMenuUiTest.java
+++ b/src/test/java/vimicalc/controller/HelpMenuUiTest.java
@@ -96,6 +96,10 @@ class HelpMenuUiTest {
         Label help = label("#helpLabel");
         assertTrue(help.isVisible(), "help label should be visible after :help");
         assertFalse(help.getText().isEmpty(), "help text should be populated");
+        // managed=false would flip isVisible without laying out — bounds prove it's on screen
+        assertTrue(help.getBoundsInParent().getWidth() > 700,
+            "help label should be laid out at near-pref width, not a zero-size flag flip: "
+                + help.getBoundsInParent());
 
         String pctTop = controller.helpMenu.percentage();
         assertEquals("0%", pctTop, "help starts at top of document");

--- a/src/test/java/vimicalc/controller/HelpMenuUiTest.java
+++ b/src/test/java/vimicalc/controller/HelpMenuUiTest.java
@@ -1,0 +1,130 @@
+package vimicalc.controller;
+
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Parent;
+import javafx.scene.Scene;
+import javafx.scene.control.Label;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
+import javafx.stage.Stage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.api.FxRobot;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+import vimicalc.Main;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * TestFX checks that the help menu is a scene-graph overlay (issue #45):
+ * open with {@code :help}, scroll with j/k, dismiss with ESC — without
+ * disturbing the cell selector.
+ *
+ * <p>Key events are delivered by calling {@link Controller#onKeyPressed} with
+ * synthetic events rather than OS-level key injection.</p>
+ */
+@ExtendWith(ApplicationExtension.class)
+class HelpMenuUiTest {
+
+    private Controller controller;
+    private Parent root;
+
+    @Start
+    void start(Stage stage) throws Exception {
+        FXMLLoader loader = new FXMLLoader(Main.class.getResource("GUI.fxml"));
+        root = loader.load();
+        controller = loader.getController();
+        Scene scene = new Scene(root, 900, 600);
+        scene.setOnKeyPressed(controller::onKeyPressed);
+        stage.setScene(scene);
+        stage.show();
+    }
+
+    private Label label(String fxId) {
+        return (Label) root.lookup(fxId);
+    }
+
+    private void press(FxRobot robot, KeyCode code, String text) {
+        KeyEvent event = new KeyEvent(
+            KeyEvent.KEY_PRESSED, text, text, code,
+            false, false, false, false
+        );
+        robot.interact(() -> controller.onKeyPressed(event));
+    }
+
+    private void press(FxRobot robot, KeyCode code) {
+        String text = code.isLetterKey() || code.isDigitKey()
+            ? code.getName().toLowerCase()
+            : "";
+        if (code == KeyCode.SEMICOLON) text = ";";
+        if (code == KeyCode.H) text = "h";
+        if (code == KeyCode.E) text = "e";
+        if (code == KeyCode.L) text = "l";
+        if (code == KeyCode.P) text = "p";
+        if (code == KeyCode.J) text = "j";
+        if (code == KeyCode.K) text = "k";
+        press(robot, code, text);
+    }
+
+    private void openHelp(FxRobot robot) {
+        // App uses ';' for command mode (not ':')
+        press(robot, KeyCode.SEMICOLON);
+        press(robot, KeyCode.H);
+        press(robot, KeyCode.E);
+        press(robot, KeyCode.L);
+        press(robot, KeyCode.P);
+        press(robot, KeyCode.ENTER, "\n");
+    }
+
+    @Test
+    void helpLabelHiddenAtStartup() {
+        Label help = label("#helpLabel");
+        assertNotNull(help, "help overlay label must be present");
+        assertFalse(help.isVisible(), "help label starts hidden");
+        assertNotEquals(Mode.HELP, controller.currMode);
+    }
+
+    @Test
+    void helpCommandShowsOverlayAndEscHidesWithoutMovingCursor(FxRobot robot) {
+        int xBefore = controller.cellSelector.getXCoord();
+        int yBefore = controller.cellSelector.getYCoord();
+
+        openHelp(robot);
+
+        assertEquals(Mode.HELP, controller.currMode);
+        Label help = label("#helpLabel");
+        assertTrue(help.isVisible(), "help label should be visible after :help");
+        assertFalse(help.getText().isEmpty(), "help text should be populated");
+
+        String pctTop = controller.helpMenu.percentage();
+        assertEquals("0%", pctTop, "help starts at top of document");
+
+        press(robot, KeyCode.J);
+        String pctAfterJ = controller.helpMenu.percentage();
+        assertNotEquals(pctTop, pctAfterJ, "j should advance scroll percentage");
+
+        press(robot, KeyCode.K);
+        assertEquals(pctTop, controller.helpMenu.percentage(),
+            "k should scroll back to previous percentage");
+
+        press(robot, KeyCode.ESCAPE);
+
+        assertEquals(Mode.NORMAL, controller.currMode);
+        assertFalse(help.isVisible(), "help label should hide on ESC");
+        assertEquals(xBefore, controller.cellSelector.getXCoord(),
+            "ESC from help must not move the cell selector X");
+        assertEquals(yBefore, controller.cellSelector.getYCoord(),
+            "ESC from help must not move the cell selector Y");
+    }
+
+    @Test
+    void shortHelpCommandAlsoOpensOverlay(FxRobot robot) {
+        press(robot, KeyCode.SEMICOLON);
+        press(robot, KeyCode.H);
+        press(robot, KeyCode.ENTER, "\n");
+
+        assertEquals(Mode.HELP, controller.currMode);
+        assertTrue(label("#helpLabel").isVisible());
+    }
+}


### PR DESCRIPTION
Closes #45. Part 4 of the canvas→FXML chrome migration (#42 → #43 → #44 → **#45**; follow-up #46).

## What

The modal help screen is a hidden scene-graph `Label` on `overlayPane`. That removes the repaint-under-overlay dance and the view→controller mode callback.

- **`GUI.fxml`**: in `overlayPane`, add `Label helpLabel` at (30,30), pref 740×480, lightyellow, black text, top-left aligned, padding 10, `visible=false` / `mouseTransparent=true` (default managed; only visibility is toggled).
- **`HelpMenu(Label)`**: keep static help text, `position`, `navigate` (j/k/ESC), `percentage()`. `drawText` → private `updateText` (24-line slice, no `gc`). Add `show()` / `hide()`. Drop `GraphicsContext`, `Consumer<Mode>`, and `simpleRect` — ESC only resets scroll; Controller owns mode and hide.
- **`Controller`**: HELP branch is navigate + percentage + on ESC hide/NORMAL/restore cell text (no `picture.resend` / selector redraw). `:h`/`:help`/`:?` path calls `show()` instead of re-dispatching `onKeyPressed`.
- **`HelpMenuUiTest`**: open via `;help` ENTER → HELP + visible label; j/k change percentage; ESC → NORMAL, label hidden, cell selector coords unchanged. Also covers short `;h`.

## Verification

- On **kubuntu** with Xvfb: `xvfb-run -a ./gradlew --no-daemon clean test` — **BUILD SUCCESSFUL** (includes new `HelpMenuUiTest`).
- Manual (when a display is available): open help over a scrolled/zoomed sheet with colored cells, scroll j/k, ESC — sheet pixel-intact with no repaint flash.

## Spec correction

Dropped `managed="false"` from `helpLabel` (spec error flagged in review). Label stays layout-managed; `show()`/`hide()` only toggle `visible`.


🤖 Generated with Grok Build
