### PR TITLE
Chrome migration cleanups (dead constants, test wiring, cosmetic parity)

### DIFF
--- a/src/main/java/vimicalc/view/Defaults.java
+++ b/src/main/java/vimicalc/view/Defaults.java
@@ -21,10 +21,6 @@ public final class Defaults {
     public static final int GUTTER_W = DEFAULT_CELL_W / 2;
     /** Height in pixels of the column-letter header row ({@link FirstRow}) on the top edge. */
     public static final int HEADER_H = DEFAULT_CELL_H;
-    /** Height in pixels of the status bar ({@link StatusBar}) row below the grid. */
-    public static final int STATUS_BAR_H = DEFAULT_CELL_H + 4;
-    /** Height in pixels of the information bar ({@link InfoBar}) at the bottom edge. */
-    public static final int INFO_BAR_H = DEFAULT_CELL_H;
     /** Default font size in points (matches the JavaFX canvas default font). */
     public static final int DEFAULT_FONT_SIZE = 13;
     /** Default view zoom factor (100%). */

--- a/src/main/resources/vimicalc/GUI.fxml
+++ b/src/main/resources/vimicalc/GUI.fxml
@@ -16,7 +16,7 @@
         <Pane fx:id="overlayPane" mouseTransparent="true" pickOnBounds="false" prefHeight="548.0" prefWidth="900.0">
           <children>
             <Label fx:id="keyStrokeLabel" alignment="CENTER" focusTraversable="false" layoutX="0.0" layoutY="0.0" prefHeight="24.0" prefWidth="48.0" style="-fx-background-color: lightgreen; -fx-text-fill: blue;" text="" />
-            <Label fx:id="helpLabel" alignment="TOP_LEFT" focusTraversable="false" layoutX="30.0" layoutY="30.0" mouseTransparent="true" prefHeight="480.0" prefWidth="740.0" style="-fx-background-color: lightyellow; -fx-text-fill: black; -fx-padding: 10;" text="" visible="false" wrapText="true" />
+            <Label fx:id="helpLabel" alignment="TOP_LEFT" focusTraversable="false" layoutX="30.0" layoutY="30.0" prefHeight="480.0" prefWidth="740.0" style="-fx-background-color: lightyellow; -fx-text-fill: black; -fx-padding: 10;" text="" visible="false" wrapText="true" />
           </children>
         </Pane>
       </children>
@@ -30,7 +30,7 @@
     </HBox>
     <HBox fx:id="infoRow" alignment="CENTER_LEFT" prefHeight="24.0" prefWidth="900.0" style="-fx-background-color: white;">
       <children>
-        <Label fx:id="infoLabel" focusTraversable="false" text="(=I)" />
+        <Label fx:id="infoLabel" focusTraversable="false" style="-fx-padding: 0 0 0 2;" text="(=I)" />
         <Region HBox.hgrow="ALWAYS" />
         <Label fx:id="exprLabel" focusTraversable="false" style="-fx-padding: 0 4 0 0;" text="" />
       </children>

--- a/src/test/java/vimicalc/controller/ChromeLabelsUiTest.java
+++ b/src/test/java/vimicalc/controller/ChromeLabelsUiTest.java
@@ -5,7 +5,6 @@ import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.control.Label;
 import javafx.scene.input.KeyCode;
-import javafx.scene.input.KeyEvent;
 import javafx.stage.Stage;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,9 +19,9 @@ import static org.junit.jupiter.api.Assertions.*;
  * TestFX checks that bottom-chrome Labels track app state after the scene-graph
  * migration (issue #43). Labels are queryable via {@code fx:id} without pixel reads.
  *
- * <p>Key events are delivered by calling {@link Controller#onKeyPressed} with
- * synthetic events rather than OS-level key injection, so the suite stays reliable
- * without a focused display window.</p>
+ * <p>Keys are injected with {@link FxRobot#type(KeyCode...)} through the
+ * scene-level key handler, like the other UI tests. Run headlessly (Monocle
+ * or Xvfb); robot input is unreliable against a live display.</p>
  */
 @ExtendWith(ApplicationExtension.class)
 class ChromeLabelsUiTest {
@@ -43,27 +42,6 @@ class ChromeLabelsUiTest {
 
     private Label label(String fxId) {
         return (Label) root.lookup(fxId);
-    }
-
-    /** Delivers a KEY_PRESSED event to the controller on the JavaFX thread. */
-    private void press(FxRobot robot, KeyCode code, String text) {
-        KeyEvent event = new KeyEvent(
-            KeyEvent.KEY_PRESSED, text, text, code,
-            false, false, false, false
-        );
-        robot.interact(() -> controller.onKeyPressed(event));
-    }
-
-    private void press(FxRobot robot, KeyCode code) {
-        String text = code.isLetterKey() || code.isDigitKey()
-            ? code.getName().toLowerCase()
-            : "";
-        if (code == KeyCode.DIGIT5) text = "5";
-        if (code == KeyCode.SEMICOLON) text = ";";
-        if (code == KeyCode.V) text = "v";
-        if (code == KeyCode.J) text = "j";
-        if (code == KeyCode.W) text = "w";
-        press(robot, code, text);
     }
 
     @Test
@@ -88,19 +66,19 @@ class ChromeLabelsUiTest {
 
     @Test
     void keyStrokeLabelTracksLastKeyPressed(FxRobot robot) {
-        press(robot, KeyCode.J);
+        robot.type(KeyCode.J);
         Label keyStroke = label("#keyStrokeLabel");
         assertEquals("J", keyStroke.getText(),
             "keystroke label should show KeyCode name after j");
 
-        press(robot, KeyCode.V);
+        robot.type(KeyCode.V);
         assertEquals("V", keyStroke.getText(),
             "keystroke label should update to the latest key");
     }
 
     @Test
     void statusLabelTracksVisualMode(FxRobot robot) {
-        press(robot, KeyCode.V);
+        robot.type(KeyCode.V);
         assertEquals(Mode.VISUAL, controller.currMode);
 
         Label status = label("#statusLabel");
@@ -111,10 +89,10 @@ class ChromeLabelsUiTest {
     @Test
     void infoLabelEchoesColonCommand(FxRobot robot) {
         // App uses ';' for command mode (not ':')
-        press(robot, KeyCode.SEMICOLON);
+        robot.type(KeyCode.SEMICOLON);
         assertEquals(Mode.COMMAND, controller.currMode);
 
-        press(robot, KeyCode.W);
+        robot.type(KeyCode.W);
         Label info = label("#infoLabel");
         assertTrue(info.getText().startsWith(":"),
             "command mode should prefix with ':': " + info.getText());
@@ -124,7 +102,7 @@ class ChromeLabelsUiTest {
 
     @Test
     void coordsLabelUpdatesOnMove(FxRobot robot) {
-        press(robot, KeyCode.J);
+        robot.type(KeyCode.J);
         Label coords = label("#coordsLabel");
         assertEquals("B3", coords.getText(),
             "moving down from B2 should show B3");
@@ -132,7 +110,7 @@ class ChromeLabelsUiTest {
 
     @Test
     void exprLabelShowsPendingKeyCommand(FxRobot robot) {
-        press(robot, KeyCode.DIGIT5);
+        robot.type(KeyCode.DIGIT5);
         Label expr = label("#exprLabel");
         assertEquals("5", expr.getText(),
             "pending multiplier should appear on exprLabel while typing a key command");

--- a/src/test/java/vimicalc/controller/HelpMenuUiTest.java
+++ b/src/test/java/vimicalc/controller/HelpMenuUiTest.java
@@ -5,7 +5,6 @@ import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.scene.control.Label;
 import javafx.scene.input.KeyCode;
-import javafx.scene.input.KeyEvent;
 import javafx.stage.Stage;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,8 +20,9 @@ import static org.junit.jupiter.api.Assertions.*;
  * open with {@code :help}, scroll with j/k, dismiss with ESC — without
  * disturbing the cell selector.
  *
- * <p>Key events are delivered by calling {@link Controller#onKeyPressed} with
- * synthetic events rather than OS-level key injection.</p>
+ * <p>Keys are injected with {@link FxRobot#type(KeyCode...)} through the
+ * scene-level key handler, like the other UI tests. Run headlessly (Monocle
+ * or Xvfb); robot input is unreliable against a live display.</p>
  */
 @ExtendWith(ApplicationExtension.class)
 class HelpMenuUiTest {
@@ -45,36 +45,11 @@ class HelpMenuUiTest {
         return (Label) root.lookup(fxId);
     }
 
-    private void press(FxRobot robot, KeyCode code, String text) {
-        KeyEvent event = new KeyEvent(
-            KeyEvent.KEY_PRESSED, text, text, code,
-            false, false, false, false
-        );
-        robot.interact(() -> controller.onKeyPressed(event));
-    }
-
-    private void press(FxRobot robot, KeyCode code) {
-        String text = code.isLetterKey() || code.isDigitKey()
-            ? code.getName().toLowerCase()
-            : "";
-        if (code == KeyCode.SEMICOLON) text = ";";
-        if (code == KeyCode.H) text = "h";
-        if (code == KeyCode.E) text = "e";
-        if (code == KeyCode.L) text = "l";
-        if (code == KeyCode.P) text = "p";
-        if (code == KeyCode.J) text = "j";
-        if (code == KeyCode.K) text = "k";
-        press(robot, code, text);
-    }
-
     private void openHelp(FxRobot robot) {
         // App uses ';' for command mode (not ':')
-        press(robot, KeyCode.SEMICOLON);
-        press(robot, KeyCode.H);
-        press(robot, KeyCode.E);
-        press(robot, KeyCode.L);
-        press(robot, KeyCode.P);
-        press(robot, KeyCode.ENTER, "\n");
+        robot.type(KeyCode.SEMICOLON);
+        robot.type(KeyCode.H, KeyCode.E, KeyCode.L, KeyCode.P);
+        robot.type(KeyCode.ENTER);
     }
 
     @Test
@@ -104,15 +79,15 @@ class HelpMenuUiTest {
         String pctTop = controller.helpMenu.percentage();
         assertEquals("0%", pctTop, "help starts at top of document");
 
-        press(robot, KeyCode.J);
+        robot.type(KeyCode.J);
         String pctAfterJ = controller.helpMenu.percentage();
         assertNotEquals(pctTop, pctAfterJ, "j should advance scroll percentage");
 
-        press(robot, KeyCode.K);
+        robot.type(KeyCode.K);
         assertEquals(pctTop, controller.helpMenu.percentage(),
             "k should scroll back to previous percentage");
 
-        press(robot, KeyCode.ESCAPE);
+        robot.type(KeyCode.ESCAPE);
 
         assertEquals(Mode.NORMAL, controller.currMode);
         assertFalse(help.isVisible(), "help label should hide on ESC");
@@ -124,9 +99,9 @@ class HelpMenuUiTest {
 
     @Test
     void shortHelpCommandAlsoOpensOverlay(FxRobot robot) {
-        press(robot, KeyCode.SEMICOLON);
-        press(robot, KeyCode.H);
-        press(robot, KeyCode.ENTER, "\n");
+        robot.type(KeyCode.SEMICOLON);
+        robot.type(KeyCode.H);
+        robot.type(KeyCode.ENTER);
 
         assertEquals(Mode.HELP, controller.currMode);
         assertTrue(label("#helpLabel").isVisible());


### PR DESCRIPTION
Closes #50. Post-migration cleanup pass after #42–#45 all landed.

## What

- **Delete `Defaults.STATUS_BAR_H` / `INFO_BAR_H`** — dead since `viewportBottom()` became `return CANVAS_H;` in #43. The bar heights are layout facts owned by `GUI.fxml` (28/24 `prefHeight`), so misleading "constants" with zero Java readers go away.
- **Test wiring**: `ChromeLabelsUiTest` and `HelpMenuUiTest` now inject keys with `robot.type(...)` through the scene-level handler, like `AppUiTest`/`ViewportSyncUiTest`, instead of feeding synthetic `KeyEvent`s straight to `Controller.onKeyPressed`. This exercises `scene.setOnKeyPressed` wiring and deletes both duplicated `press(...)` helpers (with their dead special cases).
- **Info bar inset**: restore the 2px left text padding the old canvas `fillText(…, 2, …)` had.
- **`helpLabel`**: drop redundant `mouseTransparent` (parent `overlayPane` already excludes its subtree from picking).

Not changed: the keystroke corner label still ellipsizes long key names (`BACK_SPACE` → "BACK…"). Accepting that per the discussion on #50 — condensed-glyph rendering has no Label equivalent and the ellipsis is arguably more readable.

## Verification

`./gradlew test` headless (TestFX + Monocle) — full suite green, including both rewritten test classes, which confirms robot key injection reaches the app through the scene handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)