### PR TITLE
Make the window resizable; grid canvas tracks available space

### DIFF
--- a/src/main/java/vimicalc/Main.java
+++ b/src/main/java/vimicalc/Main.java
@@ -2,7 +2,6 @@ package vimicalc;
 
 import javafx.application.Application;
 import javafx.fxml.FXMLLoader;
-import javafx.scene.Group;
 import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
@@ -26,12 +25,14 @@ public class Main extends Application {
     public void start(Stage primaryStage) throws Exception {
         FXMLLoader fxmlLoader = new FXMLLoader(Main.class.getResource("GUI.fxml"));
 
-        Group root = new Group((Parent) fxmlLoader.load());
+        Parent root = fxmlLoader.load();
         Controller ctrl = fxmlLoader.getController();
 
         Scene scene = new Scene(root, 900, 600);
         scene.setOnKeyPressed(ctrl::onKeyPressed);
         primaryStage.setTitle("WeSpreadSheet");
+        primaryStage.setMinWidth(320);
+        primaryStage.setMinHeight(240);
         primaryStage.setScene(scene);
         primaryStage.show();
     }

--- a/src/main/java/vimicalc/controller/Controller.java
+++ b/src/main/java/vimicalc/controller/Controller.java
@@ -45,7 +45,7 @@ import static vimicalc.Main.arg1;
  */
 public class Controller implements Initializable {
     int CANVAS_W;
-    private int CANVAS_H;
+    int CANVAS_H;
 
     /*CD
     private int MOUSE_X;
@@ -833,6 +833,33 @@ public class Controller implements Initializable {
                 else infoBar.setInfobarTxt(e.getMessage());
             }
         }
+        // Track the available area: canvasStack has VBox.vgrow=ALWAYS, so its
+        // laid-out size follows the window. At FXML-load time it is 0x0 and
+        // nothing fires; the first layout pulse delivers the initial size,
+        // which matches the FXML-seeded CANVAS_W/H and no-ops.
+        canvasStack.widthProperty().addListener((obs, oldV, newV) -> onCanvasStackResized());
+        canvasStack.heightProperty().addListener((obs, oldV, newV) -> onCanvasStackResized());
+    }
+
+    /** Applies the canvas stack's laid-out size to the grid viewport. */
+    private void onCanvasStackResized() {
+        int w = (int) canvasStack.getWidth(), h = (int) canvasStack.getHeight();
+        if (w <= 0 || h <= 0) return;
+        editorOps.applyViewportSize(w, h);
+    }
+
+    /**
+     * Updates the tracked canvas dimensions and resizes the canvas node.
+     * Must run before any repaint: resizing a {@link Canvas} clears it.
+     *
+     * @param w the new canvas width in pixels
+     * @param h the new canvas height in pixels
+     */
+    void setCanvasSize(int w, int h) {
+        CANVAS_W = w;
+        CANVAS_H = h;
+        canvas.setWidth(w);
+        canvas.setHeight(h);
     }
 
     /**

--- a/src/main/java/vimicalc/controller/EditorOperations.java
+++ b/src/main/java/vimicalc/controller/EditorOperations.java
@@ -106,6 +106,55 @@ public class EditorOperations {
     }
 
     /**
+     * Applies a new canvas (grid viewport) size after a window resize and
+     * re-renders everything: the layout is regenerated for the new dimensions,
+     * the grid, headers, and cursor are repainted, and the standard scroll
+     * correction keeps the selected cell visible when the viewport shrinks.
+     *
+     * <p>Unlike {@link #applyZoom(double)}, this can run in any editing mode,
+     * so it uses {@link CellSelector#resync()} (which preserves an in-progress
+     * INSERT/FORMULA edit buffer) instead of
+     * {@link CellSelector#readCell(java.util.ArrayList)}, and it leaves the
+     * info bar untouched (it may be showing a pending command or the help
+     * scroll percentage).</p>
+     *
+     * @param w the new canvas width in pixels
+     * @param h the new canvas height in pixels
+     */
+    public void applyViewportSize(int w, int h) {
+        // Never let the grid degenerate below one default cell; unreachable
+        // through the stage minimum size, but layout is not under our control.
+        w = Math.max(w, GUTTER_W + DEFAULT_CELL_W);
+        h = Math.max(h, HEADER_H + DEFAULT_CELL_H);
+        if (w == ctrl.CANVAS_W && h == ctrl.CANVAS_H) return;
+        ctrl.setCanvasSize(w, h);
+
+        // Guarantee the boundary arrays cover the cursor after regeneration:
+        // generate() only walks ~2 cells past the new viewport edge or to
+        // maxXC/maxYC, so a sharp shrink while deep-scrolled would otherwise
+        // leave the cursor column/row outside the arrays. Same grow-only bump
+        // VISUAL mode uses.
+        Positions positions = ctrl.camera.picture.metadata();
+        positions.setMaxXC(Math.max(positions.getMaxXC(), ctrl.cellSelector.getXCoord()));
+        positions.setMaxYC(Math.max(positions.getMaxYC(), ctrl.cellSelector.getYCoord()));
+
+        positions.setViewport(w - GUTTER_W, h - HEADER_H);
+        ctrl.camera.picture.setW(w - GUTTER_W);
+        ctrl.camera.picture.setH(h - HEADER_H);
+        ctrl.firstRow.setW(w - GUTTER_W);
+        ctrl.firstCol.setH(h - HEADER_H);
+
+        ctrl.camera.picture.take(ctrl.gc, ctrl.sheet, ctrl.selectedCoords, ctrl.camera.getAbsX(), ctrl.camera.getAbsY());
+        ctrl.camera.ready();
+        ctrl.cellSelector.resync();
+        scrollCursorIntoView();
+        ctrl.camera.picture.resend(ctrl.gc, ctrl.camera.getAbsX(), ctrl.camera.getAbsY());
+        ctrl.cellSelector.resync();
+        updateVisualState();
+        ctrl.cellSelector.draw(ctrl.gc);
+    }
+
+    /**
      * Moves the cell selector one cell to the left. Handles viewport scrolling
      * when the cursor reaches the left edge, and boundary checks.
      */

--- a/src/main/java/vimicalc/view/CellSelector.java
+++ b/src/main/java/vimicalc/view/CellSelector.java
@@ -216,6 +216,24 @@ public class CellSelector extends simpleRect {
     }
 
     /**
+     * Re-derives the pixel rectangle (and merged-area size) from the current
+     * grid layout without replacing {@link #selectedCell}. Unlike
+     * {@link #readCell(ArrayList)}, this preserves text being typed in
+     * INSERT/FORMULA mode, so it is safe in any mode. Call after a layout
+     * change that didn't move the cursor (e.g. a window resize).
+     */
+    public void resync() {
+        if (selectedCell.isMergeStart() && modeSupplier.get() != Mode.VISUAL) {
+            Cell mergeEnd = selectedCell.getMergeDelimiter();
+            mergedW = picPositions.getCellAbsXs()[mergeEnd.xCoord()+1] -
+                picPositions.getCellAbsXs()[xCoord];
+            mergedH = picPositions.getCellAbsYs()[mergeEnd.yCoord()+1] -
+                picPositions.getCellAbsYs()[yCoord];
+        }
+        syncToGrid();
+    }
+
+    /**
      * Derives the pixel position and size from the grid layout and the live
      * camera offset — the same formula the cell grid and headers use, so the
      * highlight can never drift away from its cell (issue #30).

--- a/src/main/java/vimicalc/view/Positions.java
+++ b/src/main/java/vimicalc/view/Positions.java
@@ -26,7 +26,9 @@ public class Positions {
      */
     private int lastXInnerEdge, lastYInnerEdge;
     private int firstXC, lastXC, firstYC, lastYC, maxXC, maxYC;
-    private final int picW, picH, DCW, DCH;
+    /** Viewport pixel dimensions; mutable via {@link #setViewport(int, int)} for window resizing. */
+    private int picW, picH;
+    private final int DCW, DCH;
     private HashMap<Integer, Integer> xOffsets;
     private HashMap<Integer, Integer> yOffsets;
     private int[] cellAbsXs, cellAbsYs;
@@ -196,6 +198,22 @@ public class Positions {
      */
     public void setZoom(double zoom) {
         this.zoom = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, zoom));
+        regenerate();
+    }
+
+    /**
+     * Sets new viewport pixel dimensions (on window resize) and regenerates
+     * positions at the last viewport edges. Like {@link #setZoom(double)},
+     * this is safe without camera access because {@link Camera#scrollBy(int, int)}
+     * regenerates on every camera move, so the last edges always match the
+     * live offset.
+     *
+     * @param picW the new picture area width in pixels
+     * @param picH the new picture area height in pixels
+     */
+    public void setViewport(int picW, int picH) {
+        this.picW = picW;
+        this.picH = picH;
         regenerate();
     }
 

--- a/src/main/resources/vimicalc/GUI.fxml
+++ b/src/main/resources/vimicalc/GUI.fxml
@@ -10,7 +10,7 @@
 
 <VBox prefHeight="600.0" prefWidth="900.0" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1" fx:controller="vimicalc.controller.Controller">
   <children>
-    <StackPane fx:id="canvasStack" prefHeight="548.0" prefWidth="900.0">
+    <StackPane fx:id="canvasStack" minHeight="0.0" minWidth="0.0" prefHeight="548.0" prefWidth="900.0" VBox.vgrow="ALWAYS">
       <children>
         <Canvas fx:id="canvas" height="548.0" width="900.0" />
         <Pane fx:id="overlayPane" mouseTransparent="true" pickOnBounds="false" prefHeight="548.0" prefWidth="900.0">

--- a/src/test/java/vimicalc/controller/AppUiTest.java
+++ b/src/test/java/vimicalc/controller/AppUiTest.java
@@ -39,6 +39,10 @@ class AppUiTest {
         Scene scene = new Scene(root, 900, 600);
         scene.setOnKeyPressed(controller::onKeyPressed);
         stage.setScene(scene);
+        // TestFX reuses one primary stage across test classes; with the
+        // resizable layout (#46) content follows the stage, so pin the size.
+        stage.setWidth(900);
+        stage.setHeight(600);
         stage.show();
     }
 

--- a/src/test/java/vimicalc/controller/ChromeLabelsUiTest.java
+++ b/src/test/java/vimicalc/controller/ChromeLabelsUiTest.java
@@ -37,6 +37,10 @@ class ChromeLabelsUiTest {
         Scene scene = new Scene(root, 900, 600);
         scene.setOnKeyPressed(controller::onKeyPressed);
         stage.setScene(scene);
+        // TestFX reuses one primary stage across test classes; with the
+        // resizable layout (#46) content follows the stage, so pin the size.
+        stage.setWidth(900);
+        stage.setHeight(600);
         stage.show();
     }
 
@@ -117,9 +121,16 @@ class ChromeLabelsUiTest {
     }
 
     @Test
-    void canvasIsGridOnlyHeight() {
-        assertEquals(900, controller.CANVAS_W);
-        assertEquals(548, controller.viewportBottom(),
+    void canvasIsGridOnly() {
+        javafx.scene.canvas.Canvas canvas = (javafx.scene.canvas.Canvas) root.lookup("#canvas");
+        javafx.scene.layout.StackPane stack = (javafx.scene.layout.StackPane) root.lookup("#canvasStack");
+        assertEquals((int) canvas.getWidth(), controller.CANVAS_W,
+            "tracked canvas width must match the canvas node");
+        assertEquals((int) canvas.getHeight(), controller.viewportBottom(),
             "viewport bottom equals canvas height after chrome leaves the canvas");
+        assertEquals((int) stack.getWidth(), (int) canvas.getWidth(),
+            "the canvas must fill the canvas stack");
+        assertEquals((int) stack.getHeight(), (int) canvas.getHeight(),
+            "the canvas must fill the canvas stack");
     }
 }

--- a/src/test/java/vimicalc/controller/HelpMenuUiTest.java
+++ b/src/test/java/vimicalc/controller/HelpMenuUiTest.java
@@ -38,6 +38,10 @@ class HelpMenuUiTest {
         Scene scene = new Scene(root, 900, 600);
         scene.setOnKeyPressed(controller::onKeyPressed);
         stage.setScene(scene);
+        // TestFX reuses one primary stage across test classes; with the
+        // resizable layout (#46) content follows the stage, so pin the size.
+        stage.setWidth(900);
+        stage.setHeight(600);
         stage.show();
     }
 

--- a/src/test/java/vimicalc/controller/MergeInteractionUiTest.java
+++ b/src/test/java/vimicalc/controller/MergeInteractionUiTest.java
@@ -35,6 +35,10 @@ class MergeInteractionUiTest {
         Scene scene = new Scene(root, 900, 600);
         scene.setOnKeyPressed(controller::onKeyPressed);
         stage.setScene(scene);
+        // TestFX reuses one primary stage across test classes; with the
+        // resizable layout (#46) content follows the stage, so pin the size.
+        stage.setWidth(900);
+        stage.setHeight(600);
         stage.show();
     }
 

--- a/src/test/java/vimicalc/controller/ResizeUiTest.java
+++ b/src/test/java/vimicalc/controller/ResizeUiTest.java
@@ -1,0 +1,178 @@
+package vimicalc.controller;
+
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Parent;
+import javafx.scene.Scene;
+import javafx.scene.canvas.Canvas;
+import javafx.scene.input.KeyCode;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.api.FxRobot;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+import org.testfx.util.WaitForAsyncUtils;
+import vimicalc.Main;
+import vimicalc.view.Positions;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static vimicalc.view.Defaults.*;
+
+/**
+ * Tests for issue #46: the window is resizable and the grid canvas tracks the
+ * available space. Growing reveals more cells without moving the camera;
+ * shrinking scrolls the selected cell back into view; the chrome rows stay
+ * pinned to the bottom; and the issue #30 cursor alignment invariant holds
+ * across every size change.
+ */
+@ExtendWith(ApplicationExtension.class)
+class ResizeUiTest {
+
+    private Controller controller;
+    private Parent root;
+    private Stage stage;
+    private Scene scene;
+
+    @Start
+    void start(Stage stage) throws Exception {
+        this.stage = stage;
+        FXMLLoader loader = new FXMLLoader(Main.class.getResource("GUI.fxml"));
+        root = loader.load();
+        controller = loader.getController();
+        scene = new Scene(root, 900, 600);
+        scene.setOnKeyPressed(controller::onKeyPressed);
+        stage.setScene(scene);
+        // TestFX reuses one primary stage across test classes; with the
+        // resizable layout (#46) content follows the stage, so pin the size.
+        stage.setWidth(900);
+        stage.setHeight(600);
+        stage.show();
+    }
+
+    private void resizeStage(FxRobot robot, double w, double h) {
+        robot.interact(() -> {
+            stage.setWidth(w);
+            stage.setHeight(h);
+        });
+        WaitForAsyncUtils.waitForFxEvents();
+    }
+
+    private Canvas canvas() {
+        return (Canvas) root.lookup("#canvas");
+    }
+
+    private StackPane canvasStack() {
+        return (StackPane) root.lookup("#canvasStack");
+    }
+
+    @Test
+    void growRevealsMoreGridWithoutMovingCamera(FxRobot robot) {
+        int prevAbsX = controller.camera.getAbsX(), prevAbsY = controller.camera.getAbsY();
+        int prevLastXC = controller.camera.picture.metadata().getLastXC();
+
+        resizeStage(robot, 1200, 720);
+
+        assertTrue(canvasStack().getWidth() > 900,
+            "the canvas stack must claim the extra window width");
+        assertEquals((int) canvasStack().getWidth(), (int) canvas().getWidth(),
+            "the canvas must track the canvas stack's width");
+        assertEquals((int) canvasStack().getHeight(), (int) canvas().getHeight(),
+            "the canvas must track the canvas stack's height");
+        assertEquals((int) canvas().getWidth(), controller.CANVAS_W);
+        assertEquals((int) canvas().getHeight(), controller.viewportBottom());
+
+        assertEquals(prevAbsX, controller.camera.getAbsX(), "growing must not move the camera");
+        assertEquals(prevAbsY, controller.camera.getAbsY(), "growing must not move the camera");
+        assertTrue(controller.camera.picture.metadata().getLastXC() > prevLastXC,
+            "a wider viewport must make more columns visible");
+        assertCursorGridAligned();
+
+        HBox infoRow = (HBox) root.lookup("#infoRow");
+        assertEquals(scene.getHeight(),
+            infoRow.localToScene(infoRow.getBoundsInLocal()).getMaxY(), 0.5,
+            "the info row must stay pinned to the bottom of the window");
+    }
+
+    @Test
+    void shrinkWidthPullsCursorBackIntoView(FxRobot robot) {
+        // Same setup as ViewportSyncUiTest: 8 L presses scroll rightward,
+        // leaving the cursor flush against the right edge.
+        for (int i = 0; i < 8; i++) robot.type(KeyCode.L);
+        int prevAbsX = controller.camera.getAbsX();
+        assertTrue(prevAbsX > GUTTER_W, "rightward scroll expected");
+
+        resizeStage(robot, 600, 600);
+
+        assertEquals(controller.CANVAS_W,
+            controller.cellSelector.getX() + controller.cellSelector.getW(),
+            "after a width shrink the cursor must sit flush against the new right edge");
+        assertTrue(controller.camera.getAbsX() > prevAbsX,
+            "the camera must scroll right to keep the cursor visible");
+        assertCursorGridAligned();
+    }
+
+    @Test
+    void shrinkHeightPullsCursorBackIntoView(FxRobot robot) {
+        for (int i = 0; i < 21; i++) robot.type(KeyCode.J);
+        int prevAbsY = controller.camera.getAbsY();
+        assertTrue(prevAbsY > HEADER_H, "downward scroll expected");
+
+        resizeStage(robot, 900, 400);
+
+        assertEquals(controller.viewportBottom(),
+            controller.cellSelector.getY() + controller.cellSelector.getH(),
+            "after a height shrink the cursor must sit flush against the new bottom edge");
+        assertTrue(controller.camera.getAbsY() > prevAbsY,
+            "the camera must scroll down to keep the cursor visible");
+        assertCursorGridAligned();
+    }
+
+    @Test
+    void sharpShrinkWhileDeepScrolledDoesNotThrow(FxRobot robot) {
+        // Regression: generate() only extends the boundary arrays ~2 cells past
+        // the new viewport edge, so a sharp shrink while deep-scrolled on empty
+        // cells used to leave the cursor column outside the arrays (AIOOBE in
+        // syncToGrid/scrollCursorIntoView) without the maxXC coverage bump.
+        for (int i = 0; i < 20; i++) robot.type(KeyCode.L);
+
+        resizeStage(robot, 400, 600);
+
+        assertEquals(controller.CANVAS_W,
+            controller.cellSelector.getX() + controller.cellSelector.getW(),
+            "cursor must land flush at the new right edge after a sharp shrink");
+        assertCursorGridAligned();
+    }
+
+    @Test
+    void resizeDuringInsertPreservesEditBuffer(FxRobot robot) {
+        robot.type(KeyCode.I);
+        assertEquals(Mode.INSERT, controller.currMode);
+        robot.type(KeyCode.H, KeyCode.I);
+        assertEquals("hi", controller.cellSelector.getSelectedCell().txt(),
+            "sanity: typed text lives in the edit buffer");
+
+        resizeStage(robot, 700, 500);
+
+        assertEquals(Mode.INSERT, controller.currMode,
+            "a resize must not change the editing mode");
+        assertEquals("hi", controller.cellSelector.getSelectedCell().txt(),
+            "a resize mid-edit must not discard the INSERT buffer");
+        assertCursorGridAligned();
+    }
+
+    /** The issue #30 invariant, same formula as ViewportSyncUiTest. */
+    private void assertCursorGridAligned() {
+        Positions pos = controller.camera.picture.metadata();
+        int xc = controller.cellSelector.getXCoord(), yc = controller.cellSelector.getYCoord();
+        assertEquals(pos.getCellAbsXs()[xc] - controller.camera.getAbsX() + GUTTER_W,
+            controller.cellSelector.getX(), "cursor X must derive from the live camera offset");
+        assertEquals(pos.getCellAbsYs()[yc] - controller.camera.getAbsY() + HEADER_H,
+            controller.cellSelector.getY(), "cursor Y must derive from the live camera offset");
+        assertEquals(pos.getCellAbsXs()[xc+1] - pos.getCellAbsXs()[xc],
+            controller.cellSelector.getW(), "cursor width must match the cell's boundary span");
+        assertEquals(pos.getCellAbsYs()[yc+1] - pos.getCellAbsYs()[yc],
+            controller.cellSelector.getH(), "cursor height must match the cell's boundary span");
+    }
+}

--- a/src/test/java/vimicalc/controller/ViewportSyncUiTest.java
+++ b/src/test/java/vimicalc/controller/ViewportSyncUiTest.java
@@ -38,6 +38,10 @@ class ViewportSyncUiTest {
         Scene scene = new Scene(root, 900, 600);
         scene.setOnKeyPressed(controller::onKeyPressed);
         stage.setScene(scene);
+        // TestFX reuses one primary stage across test classes; with the
+        // resizable layout (#46) content follows the stage, so pin the size.
+        stage.setWidth(900);
+        stage.setHeight(600);
         stage.show();
     }
 

--- a/src/test/java/vimicalc/view/PositionsTest.java
+++ b/src/test/java/vimicalc/view/PositionsTest.java
@@ -52,6 +52,38 @@ class PositionsTest {
     }
 
     @Test
+    void setViewportShrinksAndRestoresTheVisibleRange() {
+        int firstXC = positions.getFirstXC(), lastXC = positions.getLastXC();
+        int firstYC = positions.getFirstYC(), lastYC = positions.getLastYC();
+
+        positions.setViewport(400, 300);
+        assertTrue(positions.getLastXC() < lastXC,
+            "a narrower viewport must show fewer columns");
+        assertTrue(positions.getLastYC() < lastYC,
+            "a shorter viewport must show fewer rows");
+        assertEquals(firstXC, positions.getFirstXC(),
+            "resizing must relayout at the previously generated edges");
+        assertEquals(firstYC, positions.getFirstYC());
+
+        positions.setViewport(852, 552);
+        assertEquals(lastXC, positions.getLastXC(),
+            "restoring the viewport must restore the visible range");
+        assertEquals(lastYC, positions.getLastYC());
+    }
+
+    @Test
+    void setViewportGrowsTheVisibleRange() {
+        int lastXC = positions.getLastXC(), lastYC = positions.getLastYC();
+
+        positions.setViewport(1600, 900);
+
+        assertTrue(positions.getLastXC() > lastXC,
+            "a wider viewport must show more columns");
+        assertTrue(positions.getLastYC() > lastYC,
+            "a taller viewport must show more rows");
+    }
+
+    @Test
     void applyOffsetWidensOnlyTheTargetColumn() {
         int firstXC = positions.getFirstXC();
 


### PR DESCRIPTION
Closes #46 — the follow-up to the canvas→FXML chrome migration (#42–#45, cleanup #50).

## What

- **`Main`**: drop the non-resizable `Group` wrapper (the root `VBox` now fills the scene); stage minimum 320×240.
- **`GUI.fxml`**: `canvasStack` gets `VBox.vgrow="ALWAYS"` and explicit `minWidth/minHeight="0"` — without the zero min, the non-resizable `Canvas` ratchets the StackPane's computed minimum up on every grow, so the window could never shrink back.
- **`Controller`**: listens to `canvasStack`'s laid-out size (fires on FX-thread layout pulses; 0×0 at FXML-load time, and the first pulse matches the FXML-seeded size and no-ops). `setCanvasSize` resizes the `Canvas` node *before* any repaint (resizing a Canvas clears it).
- **`EditorOperations.applyViewportSize`**: the resize counterpart of `applyZoom` — update `Positions`/`Picture`/header dims in place, regenerate at the current camera edges (camera never moves on grow), repaint, then the standard scroll correction pulls the cursor flush to the new edge on shrink.
- **`Positions.setViewport`**: `picW/picH` are no longer final; same shape as `setZoom`.

## Two correctness guards worth reviewing

1. **Boundary-array coverage**: `generate()` only walks ~2 cells past the new viewport edge (or `maxXC`), so a sharp shrink while deep-scrolled on empty cells left the cursor column outside `cellAbsXs` → `ArrayIndexOutOfBoundsException`. `applyViewportSize` bumps `maxXC/maxYC` to the cursor first (the same grow-only bump VISUAL mode uses). Pinned by `ResizeUiTest.sharpShrinkWhileDeepScrolledDoesNotThrow`.
2. **`CellSelector.resync()`** instead of `readCell`: `readCell` replaces `selectedCell`, which would silently discard an in-progress INSERT/FORMULA edit buffer — unlike zoom, a resize can happen in any mode. Pinned by `ResizeUiTest.resizeDuringInsertPreservesEditBuffer`.

## Behavior notes (intentional)

- Growing while deep-scrolled reveals more cells and leaves the camera put — the camera never scrolls back on its own (established behavior).
- The help overlay keeps its fixed 740×480 and clips on very small windows.
- The per-keystroke `System.out` logging also runs per resize pulse; existing style, not addressed here.

## Tests

- New `ResizeUiTest` (5 tests): grow tracks the stack and moves no camera, width/height shrinks pull the cursor flush to the new edge, the AIOOBE regression, and the INSERT-buffer guard — all through real stage resizes, asserting the issue #30 alignment invariant.
- `PositionsTest`: `setViewport` shrink/restore/grow of the visible range.
- `ChromeLabelsUiTest.canvasIsGridOnly`: pinned 900/548 replaced with canvas==stack==tracked-size invariants.
- **All UI tests now pin the stage to 900×600 in `@Start`**: TestFX reuses one primary stage across classes in a JVM, and with a responsive layout a stage size leaked from a previous class resizes the content under the test (this actually broke `ViewportSyncUiTest` until pinned).

Full suite green headless (TestFX + Monocle). Screenshot evidence from a probe run: at 1280×800 the grid fills the window with no stale bands and the bars pinned; at 640×480 after a rightward scroll the cursor sits flush at the new right edge; help renders at small sizes with the accepted clipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)