### PR TITLE
Add :gridlines command toggling cell gridline rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ VimiCalc (also called WeSpreadSheet) combines the functionality of a traditional
 | `:cellColor [color]` | Set cell background color |
 | `:txtColor [color]` | Set text color |
 | `:boldTxt` | Toggle bold text |
+| `:gridlines` | Toggle cell gridlines |
 
 ## Formula Examples
 

--- a/src/main/java/vimicalc/model/Command.java
+++ b/src/main/java/vimicalc/model/Command.java
@@ -127,6 +127,8 @@ public class Command extends Interpretable {
                     fontSize((int) command[1].getVal(), sheet);
                 }
             }
+            // Global view toggle — like :zoom, ignores xC/yC.
+            case "gridlines" -> sheet.getPositions().toggleGridlines();
             case "zoom" -> {
                 // Global view zoom — unlike :resCol/:fontSize, ignores xC/yC.
                 if (command.length == 1) sheet.getPositions().setZoom(DEFAULT_ZOOM);

--- a/src/main/java/vimicalc/view/HelpMenu.java
+++ b/src/main/java/vimicalc/view/HelpMenu.java
@@ -51,6 +51,7 @@ public class HelpMenu {
         "\t Formatting commands without an argument reset the property to its default.",
         "\t View zoom: :zoom [25-400] sets the zoom percentage (no argument resets to 100%),",
         "\t or use Ctrl-= / Ctrl-- / Ctrl-0 in NORMAL mode to zoom in / out / reset.",
+        "\t :gridlines toggles the cell gridlines on and off.",
         "\n",
         "And then we have KeyCommands, which are basically actions made up of keyboard shortcuts entered in",
         "NORMAL mode. They appear at the bottom right of the window as you type.",

--- a/src/main/java/vimicalc/view/Picture.java
+++ b/src/main/java/vimicalc/view/Picture.java
@@ -80,6 +80,7 @@ public class Picture extends simpleRect {
     public void resend(GraphicsContext gc, int absX, int absY) {
         if (!isntReady) {
             super.draw(gc);
+            drawGridlines(gc, absX, absY);
             drawVCells(gc, absX, absY);
         }
         isntReady = false;
@@ -100,6 +101,7 @@ public class Picture extends simpleRect {
     public void take(GraphicsContext gc, @NotNull Sheet sheet, ArrayList<int[]> selectedCoords, int absX, int absY) {
         visibleCells = new ArrayList<>();
         super.draw(gc);
+        drawGridlines(gc, absX, absY);
 
         for (Cell c : sheet.getCells()) {
             // A merge-start draws the whole merged block, so it must stay
@@ -139,6 +141,37 @@ public class Picture extends simpleRect {
      */
     public void setIsntReady(boolean isntReady) {
         this.isntReady = isntReady;
+    }
+
+    /**
+     * Strokes the cell gridlines at every visible column and row boundary,
+     * unless they are toggled off (the {@code :gridlines} command). Drawn
+     * directly over the background so VISUAL-selection and cell-formatting
+     * fills cover the lines, as in other spreadsheets.
+     */
+    private void drawGridlines(@NotNull GraphicsContext gc, int absX, int absY) {
+        if (!metadata.gridlinesOn()) return;
+
+        int[] absXs = metadata.getCellAbsXs();
+        int[] absYs = metadata.getCellAbsYs();
+        // Screen-space extent of the visible grid, so lines stop at the last
+        // boundary instead of running past the laid-out cells.
+        double left = absXs[metadata.getFirstXC()] - absX + GUTTER_W;
+        double right = absXs[metadata.getLastXC() + 1] - absX + GUTTER_W;
+        double top = absYs[metadata.getFirstYC()] - absY + HEADER_H;
+        double bottom = absYs[metadata.getLastYC() + 1] - absY + HEADER_H;
+
+        gc.setStroke(Color.LIGHTGRAY);
+        gc.setLineWidth(1);
+        // The +0.5 centers each 1px stroke on the pixel so lines render crisp.
+        for (int i = metadata.getFirstXC(); i <= metadata.getLastXC() + 1; i++) {
+            double x = absXs[i] - absX + GUTTER_W + 0.5;
+            gc.strokeLine(x, top, x, bottom);
+        }
+        for (int j = metadata.getFirstYC(); j <= metadata.getLastYC() + 1; j++) {
+            double y = absYs[j] - absY + HEADER_H + 0.5;
+            gc.strokeLine(left, y, right, y);
+        }
     }
 
     /**

--- a/src/main/java/vimicalc/view/Positions.java
+++ b/src/main/java/vimicalc/view/Positions.java
@@ -37,6 +37,11 @@ public class Positions {
      * {@link #generate(int, int)}. Session-only view state — never persisted.
      */
     private double zoom = DEFAULT_ZOOM;
+    /**
+     * Whether cell gridlines are drawn, toggled by the {@code :gridlines}
+     * command. Session-only view state — never persisted.
+     */
+    private boolean gridlines = true;
 
     /**
      * Creates a new position layout manager.
@@ -199,6 +204,19 @@ public class Positions {
     public void setZoom(double zoom) {
         this.zoom = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, zoom));
         regenerate();
+    }
+
+    /** @return whether cell gridlines are drawn */
+    public boolean gridlinesOn() {
+        return gridlines;
+    }
+
+    /**
+     * Flips gridline visibility. Unlike {@link #setZoom(double)} this needs no
+     * {@code regenerate()} — layout is unaffected, only what gets drawn.
+     */
+    public void toggleGridlines() {
+        gridlines = !gridlines;
     }
 
     /**

--- a/src/test/java/vimicalc/model/CommandTest.java
+++ b/src/test/java/vimicalc/model/CommandTest.java
@@ -165,6 +165,37 @@ class CommandTest {
         }
     }
 
+    // ── :gridlines ──
+
+    @Nested
+    class GridlinesTests {
+        @BeforeEach
+        void setUpPositions() {
+            // :gridlines acts on the sheet's Positions, which the bare Sheet
+            // from the outer setUp doesn't have.
+            sheet.setPositions(new Positions(852, 552, 96, 24, new HashMap<>(), new HashMap<>()));
+            sheet.getPositions().generate(48, 24);
+        }
+
+        @Test
+        void gridlinesAreOnByDefault() {
+            assertTrue(sheet.getPositions().gridlinesOn());
+        }
+
+        @Test
+        void togglesGridlinesOff() throws Exception {
+            run("gridlines");
+            assertFalse(sheet.getPositions().gridlinesOn());
+        }
+
+        @Test
+        void togglingTwiceRestoresGridlines() throws Exception {
+            run("gridlines");
+            run("gridlines");
+            assertTrue(sheet.getPositions().gridlinesOn());
+        }
+    }
+
     // ── Unknown commands ──
 
     @Nested


### PR DESCRIPTION
## Summary
- Adds a `:gridlines` colon-command that toggles cell gridline visibility.
- The canvas previously drew **no gridlines at all** — the grid look was a flat background with cell fills. `Picture` now strokes 1px light-gray lines at every visible column/row boundary, drawn under the VISUAL-selection and cell-formatting fills so colored/selected cells cover them (as in other spreadsheets).
- Gridlines are **on by default** and the flag is **session-only** view state on `Positions` (next to `zoom`, not persisted in the `.json` file).
- Documents the command in the help overlay and the README command table.

## Test plan
- [x] `./gradlew test` passes (231 tests, run headless via Monocle; new `GridlinesTests` covers default-on, toggle-off, and toggle round-trip)
- [x] Verified visually by driving the app headlessly with a throwaway TestFX probe: gridlines visible at launch, hidden after `:gridlines`, restored after toggling again; lines stay aligned with header boundaries after `:zoom 150` and after scrolling to N32

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BYDkGAmDxGSvosiADVuQWE