### PR TITLE
TAB completion for colon-command names in COMMAND mode

### DIFF
--- a/src/main/java/vimicalc/controller/CommandCompletion.java
+++ b/src/main/java/vimicalc/controller/CommandCompletion.java
@@ -1,0 +1,99 @@
+package vimicalc.controller;
+
+import org.jetbrains.annotations.NotNull;
+import vimicalc.model.Command;
+
+import java.util.List;
+
+/**
+ * Prefix-based TAB completion of colon-command names in COMMAND mode
+ * (vim {@code wildmode=full} style).
+ *
+ * <p>A completion session starts on the first {@link #next(String)} or
+ * {@link #previous(String)} call: the text typed so far becomes the prefix, and
+ * the entries of {@link Command#COMMAND_NAMES} starting with it (sorted
+ * alphabetically) become the cycle. Repeated calls cycle forward/backward
+ * through the matches, returning to the original prefix after the last match.
+ * Any other keystroke should end the session via {@link #reset()}.</p>
+ */
+public class CommandCompletion {
+    /** The text typed before completion started, or {@code null} when no session is active. */
+    private String prefix = null;
+
+    /** Command names matching {@link #prefix}, sorted alphabetically. */
+    private List<String> matches = List.of();
+
+    /**
+     * Position in the cycle: an index into {@link #matches}, or
+     * {@code matches.size()} for the original prefix.
+     */
+    private int position = 0;
+
+    /**
+     * Returns whether a completion session is in progress.
+     */
+    public boolean isActive() {
+        return prefix != null;
+    }
+
+    /**
+     * Returns the command names matching the session's prefix, sorted
+     * alphabetically. Empty when no session is active or nothing matches.
+     */
+    public List<String> getMatches() {
+        return matches;
+    }
+
+    /**
+     * Returns the index into {@link #getMatches()} of the currently selected
+     * match, or {@code -1} when the cycle is on the original prefix.
+     */
+    public int getSelectedIndex() {
+        return position == matches.size() ? -1 : position;
+    }
+
+    /** Ends the current completion session, if any. */
+    public void reset() {
+        prefix = null;
+        matches = List.of();
+        position = 0;
+    }
+
+    /**
+     * Advances the cycle to the next match, starting a session from
+     * {@code current} if none is active.
+     *
+     * @param current the command text typed so far
+     * @return the next match, or the original prefix after the last match;
+     *         {@code current} unchanged if nothing matches
+     */
+    public String next(@NotNull String current) {
+        return cycle(current, 1);
+    }
+
+    /**
+     * Moves the cycle to the previous match, starting a session from
+     * {@code current} if none is active.
+     *
+     * @param current the command text typed so far
+     * @return the previous match (the last one on a fresh session), or the
+     *         original prefix; {@code current} unchanged if nothing matches
+     */
+    public String previous(@NotNull String current) {
+        return cycle(current, -1);
+    }
+
+    private String cycle(String current, int step) {
+        if (prefix == null) {
+            prefix = current;
+            matches = Command.COMMAND_NAMES.stream()
+                .filter(name -> name.startsWith(current))
+                .sorted()
+                .toList();
+            position = matches.size();
+        }
+        // The cycle has matches.size() + 1 slots; the extra one is the prefix.
+        position = Math.floorMod(position + step, matches.size() + 1);
+        return position == matches.size() ? prefix : matches.get(position);
+    }
+}

--- a/src/main/java/vimicalc/controller/Controller.java
+++ b/src/main/java/vimicalc/controller/Controller.java
@@ -20,9 +20,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.ResourceBundle;
 
 import static javafx.scene.input.KeyCode.ESCAPE;
+import static javafx.scene.input.KeyCode.TAB;
 import static vimicalc.Main.arg1;
 
 /**
@@ -88,6 +90,8 @@ public class Controller implements Initializable {
     Camera camera;
     /** The current colon-command being composed or executed. */
     Command command;
+    /** TAB-completion state for the colon-command being composed. */
+    final CommandCompletion commandCompletion = new CommandCompletion();
     /** Displays the current cell coordinates in the status area. */
     CoordsInfo coordsInfo;
     FirstCol firstCol;
@@ -218,12 +222,21 @@ public class Controller implements Initializable {
     /**
      * Handles keyboard input in COMMAND mode. Builds up the command string
      * character by character, executing it on ENTER and cancelling on ESC.
+     * TAB / Shift+TAB cycle through command-name completions (see
+     * {@link CommandCompletion}); any other key ends the completion session.
      * Also supports entering commands from VISUAL mode via {@code ;} (SEMICOLON),
      * for applying formulas to selections.
      *
      * @param event the key event to process
      */
     private void commandInput(@NotNull KeyEvent event) {
+        // A modifier press alone (e.g. SHIFT on its way to Shift+TAB) must not
+        // end the completion session.
+        if (event.getCode() != TAB && !event.getCode().isModifierKey()
+            && commandCompletion.isActive()) {
+            commandCompletion.reset();
+            infoBar.setIBarExpr("");
+        }
         switch (event.getCode()) {
             case ESCAPE -> {
                 if (enteringCommandInVISUAL) {
@@ -317,6 +330,19 @@ public class Controller implements Initializable {
                     command.setTxt(command.getTxt().substring(0, command.getTxt().length()-1));
                 }
             }
+            case TAB -> {
+                event.consume();
+                // Only complete the command name itself: no completion for
+                // VISUAL-mode formulas or once arguments are being typed.
+                if (!enteringCommandInVISUAL && !command.getTxt().contains(" ")) {
+                    command.setTxt(event.isShiftDown()
+                        ? commandCompletion.previous(command.getTxt())
+                        : commandCompletion.next(command.getTxt()));
+                    // The candidate list goes on the right side of the info
+                    // bar; the left side shows the command text itself.
+                    infoBar.setIBarExpr(completionCandidates());
+                }
+            }
             default -> {
                 command.setTxt(command.getTxt() + event.getText());
                 infoBar.setCommandTxt(command.getTxt() + event.getText());
@@ -324,6 +350,25 @@ public class Controller implements Initializable {
         }
         if(currMode == Mode.COMMAND || currMode == Mode.VISUAL)
             infoBar.setCommandTxt(command.getTxt());
+    }
+
+    /**
+     * Formats the current completion matches for the info bar, bracketing the
+     * selected one (e.g. {@code resCol  [resRow]}).
+     *
+     * @return the candidate list, or a "no match" message when nothing matches
+     */
+    private @NotNull String completionCandidates() {
+        List<String> matches = commandCompletion.getMatches();
+        if (matches.isEmpty()) return "No matching command";
+        StringBuilder candidates = new StringBuilder();
+        for (int i = 0; i < matches.size(); i++) {
+            if (i > 0) candidates.append("  ");
+            if (i == commandCompletion.getSelectedIndex())
+                candidates.append('[').append(matches.get(i)).append(']');
+            else candidates.append(matches.get(i));
+        }
+        return candidates.toString();
     }
 
     /** Accumulates digit characters to form a numeric multiplier in VISUAL mode. */

--- a/src/main/java/vimicalc/model/Command.java
+++ b/src/main/java/vimicalc/model/Command.java
@@ -3,6 +3,8 @@ package vimicalc.model;
 import org.jetbrains.annotations.NotNull;
 import vimicalc.view.Formatting;
 
+import java.util.List;
+
 import static vimicalc.view.Defaults.DEFAULT_FONT_SIZE;
 import static vimicalc.view.Defaults.DEFAULT_ZOOM;
 
@@ -35,6 +37,17 @@ import static vimicalc.view.Defaults.DEFAULT_ZOOM;
  * default.</p>
  */
 public class Command extends Interpretable {
+    /**
+     * Every recognized command name, in the order of the class Javadoc list.
+     * Used for COMMAND-mode autocompletion; keep in sync with the switch in
+     * {@link #interpret(Token[], Sheet)} (enforced by {@code CommandTest}).
+     */
+    public static final List<String> COMMAND_NAMES = List.of(
+        "h", "help", "?", "e", "w", "wq", "q", "resCol", "resRow", "purgeDeps",
+        "cellColor", "txtColor", "boldTxt", "italicTxt", "fontSize", "fontWeight",
+        "zoom"
+    );
+
     /**
      * Creates a command from the given text at the specified cell position.
      *

--- a/src/main/java/vimicalc/view/HelpMenu.java
+++ b/src/main/java/vimicalc/view/HelpMenu.java
@@ -51,6 +51,8 @@ public class HelpMenu {
         "\t Formatting commands without an argument reset the property to its default.",
         "\t View zoom: :zoom [25-400] sets the zoom percentage (no argument resets to 100%),",
         "\t or use Ctrl-= / Ctrl-- / Ctrl-0 in NORMAL mode to zoom in / out / reset.",
+        "\t Press 'TAB' to complete the command name: it cycles through the matching commands",
+        "\t (listed on the right of the info bar), 'Shift-TAB' cycles backwards.",
         "\n",
         "And then we have KeyCommands, which are basically actions made up of keyboard shortcuts entered in",
         "NORMAL mode. They appear at the bottom right of the window as you type.",

--- a/src/test/java/vimicalc/controller/AppUiTest.java
+++ b/src/test/java/vimicalc/controller/AppUiTest.java
@@ -73,4 +73,33 @@ class AppUiTest {
         assertEquals(Mode.FORMULA, controller.currMode,
             "Pressing = should switch to FORMULA mode");
     }
+
+    @Test
+    void tabCyclesCommandNameCompletions(FxRobot robot) {
+        robot.type(KeyCode.SEMICOLON, KeyCode.R, KeyCode.E, KeyCode.S);
+        assertEquals(Mode.COMMAND, controller.currMode,
+            "Pressing ; should switch to COMMAND mode");
+
+        robot.type(KeyCode.TAB);
+        assertEquals("resCol", controller.command.getTxt(),
+            "First TAB should complete to the first matching command");
+        assertEquals("[resCol]  resRow", controller.infoBar.getIBarExpr(),
+            "The info bar's right side should list the candidates, bracketing the selection");
+
+        robot.type(KeyCode.TAB);
+        assertEquals("resRow", controller.command.getTxt(),
+            "Second TAB should cycle to the next match");
+
+        robot.type(KeyCode.TAB);
+        assertEquals("res", controller.command.getTxt(),
+            "Cycling past the last match should restore the typed prefix");
+        assertEquals(Mode.COMMAND, controller.currMode,
+            "TAB must not leave COMMAND mode");
+
+        robot.press(KeyCode.SHIFT);
+        robot.type(KeyCode.TAB);
+        robot.release(KeyCode.SHIFT);
+        assertEquals("resRow", controller.command.getTxt(),
+            "Shift+TAB should cycle backwards without the SHIFT press ending the session");
+    }
 }

--- a/src/test/java/vimicalc/controller/CommandCompletionTest.java
+++ b/src/test/java/vimicalc/controller/CommandCompletionTest.java
@@ -1,0 +1,111 @@
+package vimicalc.controller;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import vimicalc.model.Command;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CommandCompletionTest {
+
+    private CommandCompletion completion;
+
+    @BeforeEach
+    void setUp() {
+        completion = new CommandCompletion();
+    }
+
+    // ── Cycling forward ──
+
+    @Nested
+    class NextTests {
+        @Test
+        void cyclesAlphabeticallyThenReturnsToPrefix() {
+            assertEquals("resCol", completion.next("res"));
+            assertEquals("resRow", completion.next("resCol"));
+            assertEquals("res", completion.next("resRow"));
+            assertEquals("resCol", completion.next("res"));
+        }
+
+        @Test
+        void exactCommandNameStillCyclesItsExtensions() {
+            assertEquals("w", completion.next("w"));
+            assertEquals("wq", completion.next("w"));
+            assertEquals("w", completion.next("wq"));
+        }
+
+        @Test
+        void emptyPrefixMatchesEveryCommand() {
+            assertNotEquals("", completion.next(""));
+            int cycled = 1;
+            while (!completion.next("").equals("")) cycled++;
+            assertEquals(Command.COMMAND_NAMES.size(), cycled,
+                "Cycling from an empty prefix should visit every command once");
+        }
+
+        @Test
+        void noMatchReturnsInputUnchanged() {
+            assertEquals("xyz", completion.next("xyz"));
+            assertEquals("xyz", completion.next("xyz"));
+            assertTrue(completion.getMatches().isEmpty());
+        }
+    }
+
+    // ── Cycling backward ──
+
+    @Nested
+    class PreviousTests {
+        @Test
+        void freshSessionStartsAtLastMatch() {
+            assertEquals("resRow", completion.previous("res"));
+            assertEquals("resCol", completion.previous("resRow"));
+            assertEquals("res", completion.previous("resCol"));
+        }
+
+        @Test
+        void previousUndoesNext() {
+            assertEquals("resCol", completion.next("res"));
+            assertEquals("resRow", completion.next("resCol"));
+            assertEquals("resCol", completion.previous("resRow"));
+        }
+    }
+
+    // ── Session state ──
+
+    @Nested
+    class SessionTests {
+        @Test
+        void inactiveUntilFirstCycle() {
+            assertFalse(completion.isActive());
+            completion.next("res");
+            assertTrue(completion.isActive());
+        }
+
+        @Test
+        void resetStartsANewSessionWithANewPrefix() {
+            assertEquals("resCol", completion.next("res"));
+            completion.reset();
+            assertFalse(completion.isActive());
+            assertEquals("fontSize", completion.next("font"));
+            assertEquals("fontWeight", completion.next("fontSize"));
+        }
+
+        @Test
+        void selectedIndexTracksTheCycle() {
+            completion.next("res");
+            assertEquals(0, completion.getSelectedIndex());
+            completion.next("resCol");
+            assertEquals(1, completion.getSelectedIndex());
+            completion.next("resRow");
+            assertEquals(-1, completion.getSelectedIndex(),
+                "Back on the original prefix, no match is selected");
+        }
+
+        @Test
+        void matchesAreSortedAlphabetically() {
+            completion.next("res");
+            assertEquals(java.util.List.of("resCol", "resRow"), completion.getMatches());
+        }
+    }
+}

--- a/src/test/java/vimicalc/controller/KeyCommandManualTests.md
+++ b/src/test/java/vimicalc/controller/KeyCommandManualTests.md
@@ -236,3 +236,27 @@ it — Vim-like behavior, per issue #24.
 1. Select a block in VISUAL mode (`v`, move, `m`) to merge it
 2. Press Ctrl+`=` — the merged block scales as one region and its
    text scales with it
+
+## 12. Command-name completion (TAB in COMMAND mode)
+
+### 12.1 Cycle through matches
+1. Press `;` then type `res` and press Tab — command line reads `:resCol`,
+   the right side of the info bar shows `[resCol]  resRow`
+2. Press Tab again — command line reads `:resRow`, brackets move to `resRow`
+3. Press Tab again — the typed prefix `res` is restored
+4. Press Shift+Tab — cycles backwards (to `resRow`)
+
+### 12.2 Session ends on other keys
+1. Press `;`, type `font`, press Tab (→ `fontSize`), then type ` 18`
+   and press Enter — the current cell's font size changes; the candidate
+   list disappears
+2. Press `;`, type `x`, press Tab — the right side of the info bar shows
+   "No matching command", command line keeps `:x`
+3. Press `;`, press Tab with nothing typed — cycles through every command;
+   press Escape — back to NORMAL mode with no command run
+
+### 12.3 No completion for VISUAL-mode formulas or arguments
+1. Select cells in VISUAL mode, press `;`, type a formula and press Tab —
+   nothing is completed and no tab character is inserted
+2. Press `;`, type `cellColor r`, press Tab — nothing changes (completion
+   only applies before the first space)

--- a/src/test/java/vimicalc/model/CommandTest.java
+++ b/src/test/java/vimicalc/model/CommandTest.java
@@ -3,9 +3,11 @@ package vimicalc.model;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import vimicalc.view.Formatting;
 import vimicalc.view.Positions;
 
+import java.nio.file.Path;
 import java.util.HashMap;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -174,6 +176,29 @@ class CommandTest {
             Command c = new Command("frobnicate", 1, 1);
             assertThrows(Exception.class, () -> c.interpret(sheet));
             assertFalse(c.commandExists);
+        }
+    }
+
+    // ── COMMAND_NAMES (autocompletion) ──
+
+    @Nested
+    class CommandNamesTests {
+        @TempDir
+        Path tempDir;
+
+        @Test
+        void everyListedNameIsRecognizedByInterpret() {
+            for (String name : Command.COMMAND_NAMES) {
+                // The tempDir argument keeps :w / :wq from writing into the
+                // working directory; commands that reject it still count as
+                // recognized (only the default branch clears commandExists).
+                Command c = new Command(name + ' ' + tempDir.resolve("out"), 2, 3);
+                try {
+                    c.interpret(sheet);
+                } catch (Exception ignored) {}
+                assertTrue(c.commandExists,
+                    "\"" + name + "\" is in COMMAND_NAMES but not in the interpret switch");
+            }
         }
     }
 }


### PR DESCRIPTION
## What

Vim-style (`wildmode=full`) TAB completion while composing a `:`-command:

- **TAB** completes the typed prefix to the first matching command name; repeated presses cycle through the matches and back to the original prefix. **Shift+TAB** cycles backwards.
- The candidate list is shown on the right side of the info bar with the current selection bracketed, e.g. `[resCol]  resRow`.
- Any other key ends the completion session. Completion applies only to the command name — not to arguments (after a space) or VISUAL-mode formulas entered via `;`.

## How

- `Command.COMMAND_NAMES` — canonical list of the 17 recognized command names; a new `CommandTest` case pins it to the `interpret` switch so they can't drift apart.
- `CommandCompletion` (new, JavaFX-free) — prefix matching + cycle state.
- `Controller.commandInput` — new `case TAB` (consumed, so it can't trigger focus traversal) and a session reset on any non-TAB, non-modifier key. Modifier-only presses are ignored so the SHIFT press preceding Shift+TAB doesn't end the session (caught during headless verification).
- Help menu text and `KeyCommandManualTests.md` §12 document the feature.

## Testing

- New `CommandCompletionTest` (cycling, backwards, no-match, session reset) and a TestFX scenario in `AppUiTest` covering TAB/Shift+TAB end to end.
- Full suite passes headless (Monocle); behavior also verified visually by driving the real app and screenshotting the info bar (`:res` → TAB → `:resCol` + `[resCol]  resRow`, then `:resCol 40` + ENTER resizes the column).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M2jHro7XYYAdNmczr17eYr