### PR TITLE
Restyle GUI with Modena-like depth on a neutral gray-blue palette

### DIFF
--- a/src/main/java/vimicalc/controller/Controller.java
+++ b/src/main/java/vimicalc/controller/Controller.java
@@ -8,7 +8,6 @@ import javafx.scene.control.Label;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Pane;
 import javafx.scene.layout.StackPane;
-import javafx.scene.paint.Color;
 import org.jetbrains.annotations.NotNull;
 import vimicalc.model.*;
 import vimicalc.view.*;
@@ -949,8 +948,7 @@ public class Controller implements Initializable {
         camera.picture.take(gc, sheet, selectedCoords, camera.getAbsX(), camera.getAbsY());
 
         cellSelector = new CellSelector(
-            new Color(0.0, 0.67, 1, 1),
-//            Color.LIMEGREEN,
+            SELECT_TINT,
             camera,
             camera.picture.metadata(),
             sheet.getCellsFormatting(),
@@ -961,7 +959,7 @@ public class Controller implements Initializable {
             HEADER_H,
             GUTTER_W,
             viewportBottom()-HEADER_H,
-            Color.LIGHTBLUE,
+            HEADER_FILL_H,
             camera,
             camera.picture.metadata()
         );
@@ -970,7 +968,7 @@ public class Controller implements Initializable {
             0,
             CANVAS_W-GUTTER_W,
             HEADER_H,
-            Color.LIGHTBLUE,
+            HEADER_FILL_V,
             camera,
             camera.picture.metadata()
         );

--- a/src/main/java/vimicalc/view/CellSelector.java
+++ b/src/main/java/vimicalc/view/CellSelector.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.function.Supplier;
 
+import static vimicalc.view.Defaults.ACCENT;
 import static vimicalc.view.Defaults.DEFAULT_FONT_SIZE;
 import static vimicalc.view.Defaults.GUTTER_W;
 import static vimicalc.view.Defaults.HEADER_H;
@@ -124,16 +125,28 @@ public class CellSelector extends simpleRect {
             , w);
         gc.setFont(prevFont);
     }
+    /**
+     * Fills the highlight rectangle, then strokes the accent border on top,
+     * inset so the 2px stroke stays within the cell's own pixels.
+     */
+    private void drawBox(@NotNull GraphicsContext gc) {
+        super.draw(gc);
+        gc.setStroke(ACCENT);
+        gc.setLineWidth(2);
+        gc.strokeRect(x + 1, y + 1, w - 2, h - 2);
+        gc.setLineWidth(1);
+    }
+
     @Override
     public void draw(@NotNull GraphicsContext gc) {
         if (!selectedCell.isMergeStart() || modeSupplier.get() == Mode.VISUAL) {
-            super.draw(gc);
+            drawBox(gc);
             if (selectedCell.txt() != null) drawTxt(gc);
         }
         else {
             int prevW = w, prevH = h;
             w = mergedW; h = mergedH;
-            super.draw(gc);
+            drawBox(gc);
             if (selectedCell.txt() != null) drawTxt(gc);
             w = prevW; h = prevH;
         }

--- a/src/main/java/vimicalc/view/Defaults.java
+++ b/src/main/java/vimicalc/view/Defaults.java
@@ -2,6 +2,9 @@ package vimicalc.view;
 
 import javafx.geometry.VPos;
 import javafx.scene.paint.Color;
+import javafx.scene.paint.CycleMethod;
+import javafx.scene.paint.LinearGradient;
+import javafx.scene.paint.Stop;
 import javafx.scene.text.TextAlignment;
 
 /**
@@ -35,6 +38,34 @@ public final class Defaults {
     public static final Color DEFAULT_CELL_C = Color.WHITE;
     /** Default cell text color. */
     public static final Color DEFAULT_TXT_C = Color.BLACK;
+    /** Lightest chrome shade; top stop of the header gradients (mirrors {@code theme.css}). */
+    public static final Color CHROME_TOP = Color.web("#f4f6f8");
+    /** Darkest chrome shade; bottom stop of the header gradients (mirrors {@code theme.css}). */
+    public static final Color CHROME_BOTTOM = Color.web("#dfe3e8");
+    /** Hairline border color separating chrome (headers, bars) from the grid. */
+    public static final Color CHROME_BORDER = Color.web("#a9b1ba");
+    /** Hairline separator color between labels inside the headers. */
+    public static final Color HEADER_SEPARATOR = Color.web("#c3cad2");
+    /** Header label text color. */
+    public static final Color HEADER_TXT = Color.web("#333333");
+    /** Cell gridline color. */
+    public static final Color GRIDLINE_C = Color.web("#d8dde3");
+    /** Accent color for the selector border and other emphasis. */
+    public static final Color ACCENT = Color.rgb(0, 171, 255);
+    /**
+     * Selection fill tint for the cell selector and VISUAL-mode ranges. Opaque
+     * on purpose: the selector repaints the cell text itself, so a translucent
+     * fill over the grid's already-drawn text would double-render it.
+     */
+    public static final Color SELECT_TINT = Color.web("#cfe9ff");
+    /** Top-lit vertical gradient filling the column header row and corner block. */
+    public static final LinearGradient HEADER_FILL_V = new LinearGradient(
+        0, 0, 0, 1, true, CycleMethod.NO_CYCLE,
+        new Stop(0, CHROME_TOP), new Stop(1, CHROME_BOTTOM));
+    /** Left-lit horizontal gradient filling the row-number gutter. */
+    public static final LinearGradient HEADER_FILL_H = new LinearGradient(
+        0, 0, 1, 0, true, CycleMethod.NO_CYCLE,
+        new Stop(0, CHROME_TOP), new Stop(1, CHROME_BOTTOM));
     /** Default vertical text position within a cell. */
     public static final VPos DEFAULT_VPOS = VPos.CENTER;
     /** Default horizontal text alignment within a cell. */

--- a/src/main/java/vimicalc/view/FirstCol.java
+++ b/src/main/java/vimicalc/view/FirstCol.java
@@ -2,12 +2,15 @@ package vimicalc.view;
 
 import javafx.geometry.VPos;
 import javafx.scene.canvas.GraphicsContext;
-import javafx.scene.paint.Color;
+import javafx.scene.paint.Paint;
 import javafx.scene.text.Font;
 import javafx.scene.text.TextAlignment;
 import org.jetbrains.annotations.NotNull;
 
+import static vimicalc.view.Defaults.CHROME_BORDER;
 import static vimicalc.view.Defaults.DEFAULT_FONT_SIZE;
+import static vimicalc.view.Defaults.HEADER_SEPARATOR;
+import static vimicalc.view.Defaults.HEADER_TXT;
 
 /**
  * The row number column displayed on the left side of the spreadsheet.
@@ -26,11 +29,11 @@ public class FirstCol extends simpleRect {
      * @param y            the y pixel position
      * @param w            the width in pixels
      * @param h            the height in pixels
-     * @param c            the background color
+     * @param c            the background fill
      * @param camera       the viewport camera the label positions derive from
      * @param picPositions the position metadata for cell layout
      */
-    public FirstCol(int x, int y, int w, int h, Color c, Camera camera, Positions picPositions) {
+    public FirstCol(int x, int y, int w, int h, Paint c, Camera camera, Positions picPositions) {
         super(x, y, w, h, c);
         this.camera = camera;
         this.picPositions = picPositions;
@@ -39,7 +42,7 @@ public class FirstCol extends simpleRect {
     @Override
     public void draw(@NotNull GraphicsContext gc) {
         super.draw(gc);
-        gc.setFill(Color.BLACK);
+        gc.setFill(HEADER_TXT);
         gc.setTextAlign(TextAlignment.CENTER);
         gc.setTextBaseline(VPos.CENTER);
         // Scale the label font with the view zoom so headers grow with the
@@ -55,5 +58,17 @@ public class FirstCol extends simpleRect {
                 , w);
         }
         gc.setFont(prevFont);
+
+        // Inset hairline separators between row labels; the +0.5 centers each
+        // 1px stroke on the pixel so lines render crisp.
+        gc.setStroke(HEADER_SEPARATOR);
+        gc.setLineWidth(1);
+        for (int yC = picPositions.getFirstYC() + 1; yC <= picPositions.getLastYC() + 1; yC++) {
+            double sepY = picPositions.getCellAbsYs()[yC] - camera.getAbsY() + y + 0.5;
+            gc.strokeLine(x + 4, sepY, x + w - 5, sepY);
+        }
+        // Edge line where the gutter meets the grid.
+        gc.setStroke(CHROME_BORDER);
+        gc.strokeLine(x + w - 0.5, y, x + w - 0.5, y + h);
     }
 }

--- a/src/main/java/vimicalc/view/FirstRow.java
+++ b/src/main/java/vimicalc/view/FirstRow.java
@@ -1,19 +1,24 @@
 package vimicalc.view;
 
 import javafx.scene.canvas.GraphicsContext;
-import javafx.scene.paint.Color;
+import javafx.scene.paint.Paint;
 import javafx.scene.text.Font;
 import javafx.scene.text.TextAlignment;
 import org.jetbrains.annotations.NotNull;
 
 import static vimicalc.utils.Conversions.toAlpha;
+import static vimicalc.view.Defaults.CHROME_BORDER;
 import static vimicalc.view.Defaults.DEFAULT_FONT_SIZE;
+import static vimicalc.view.Defaults.HEADER_SEPARATOR;
+import static vimicalc.view.Defaults.HEADER_TXT;
 
 /**
  * The column header row displayed at the top of the spreadsheet.
  *
  * <p>Renders alphabetic column labels (A, B, C, ...) centered within each
- * column, using the layout information from {@link Positions}.</p>
+ * column, using the layout information from {@link Positions}. Also paints
+ * the top-left corner block shared with {@link FirstCol}, so it must draw
+ * after the row gutter.</p>
  */
 public class FirstRow extends simpleRect {
     Camera camera;
@@ -26,11 +31,11 @@ public class FirstRow extends simpleRect {
      * @param y            the y pixel position
      * @param w            the width in pixels
      * @param h            the height in pixels
-     * @param c            the background color
+     * @param c            the background fill
      * @param camera       the viewport camera the label positions derive from
      * @param picPositions the position metadata for cell layout
      */
-    public FirstRow(int x, int y, int w, int h, Color c, Camera camera, Positions picPositions) {
+    public FirstRow(int x, int y, int w, int h, Paint c, Camera camera, Positions picPositions) {
         super(x, y, w, h, c);
         this.camera = camera;
         this.picPositions = picPositions;
@@ -39,7 +44,11 @@ public class FirstRow extends simpleRect {
     @Override
     public void draw(@NotNull GraphicsContext gc) {
         super.draw(gc);
-        gc.setFill(Color.BLACK);
+        // The corner block above the row gutter, painted with the same fill so
+        // the whole top edge reads as one continuous header surface.
+        gc.setFill(c);
+        gc.fillRect(0, y, x, h);
+        gc.setFill(HEADER_TXT);
         gc.setTextAlign(TextAlignment.CENTER);
         // Scale the label font with the view zoom so headers grow with the
         // grid; fillText's max-width squeezes labels that outgrow the header.
@@ -54,5 +63,19 @@ public class FirstRow extends simpleRect {
                 , cellWidth);
         }
         gc.setFont(prevFont);
+
+        // Inset hairline separators between column labels; the +0.5 centers
+        // each 1px stroke on the pixel so lines render crisp.
+        gc.setStroke(HEADER_SEPARATOR);
+        gc.setLineWidth(1);
+        for (int xC = picPositions.getFirstXC() + 1; xC <= picPositions.getLastXC() + 1; xC++) {
+            double sepX = picPositions.getCellAbsXs()[xC] - camera.getAbsX() + x + 0.5;
+            gc.strokeLine(sepX, y + 4, sepX, y + h - 5);
+        }
+        // Edge lines where the header meets the grid (bottom, full width
+        // including the corner) and where the corner meets the gutter.
+        gc.setStroke(CHROME_BORDER);
+        gc.strokeLine(0, y + h - 0.5, x + w, y + h - 0.5);
+        gc.strokeLine(x - 0.5, y, x - 0.5, y + h);
     }
 }

--- a/src/main/java/vimicalc/view/KeyStrokeCell.java
+++ b/src/main/java/vimicalc/view/KeyStrokeCell.java
@@ -24,11 +24,13 @@ public class KeyStrokeCell {
     }
 
     /**
-     * Sets the key stroke text to display.
+     * Sets the key stroke text to display. The chip is hidden while the text
+     * is empty so it only floats over the header corner once a key is pressed.
      *
      * @param keyStroke the key name
      */
     public void setKeyStroke(String keyStroke) {
         keyStrokeLabel.setText(keyStroke);
+        keyStrokeLabel.setVisible(keyStroke != null && !keyStroke.isEmpty());
     }
 }

--- a/src/main/java/vimicalc/view/Picture.java
+++ b/src/main/java/vimicalc/view/Picture.java
@@ -15,8 +15,10 @@ import java.util.List;
 import java.util.Map;
 
 import static vimicalc.view.Defaults.DEFAULT_FONT_SIZE;
+import static vimicalc.view.Defaults.GRIDLINE_C;
 import static vimicalc.view.Defaults.GUTTER_W;
 import static vimicalc.view.Defaults.HEADER_H;
+import static vimicalc.view.Defaults.SELECT_TINT;
 
 /**
  * The main spreadsheet grid renderer, responsible for drawing all visible cells
@@ -120,7 +122,7 @@ public class Picture extends simpleRect {
             }
         }
 
-        gc.setFill(new Color(0,0.67,1,1));
+        gc.setFill(SELECT_TINT);
         selectedCoords.forEach(c ->
             gc.fillRect(
                 metadata.getCellAbsXs()[c[0]] - absX + GUTTER_W,
@@ -161,7 +163,7 @@ public class Picture extends simpleRect {
         double top = absYs[metadata.getFirstYC()] - absY + HEADER_H;
         double bottom = absYs[metadata.getLastYC() + 1] - absY + HEADER_H;
 
-        gc.setStroke(Color.LIGHTGRAY);
+        gc.setStroke(GRIDLINE_C);
         gc.setLineWidth(1);
         // The +0.5 centers each 1px stroke on the pixel so lines render crisp.
         for (int i = metadata.getFirstXC(); i <= metadata.getLastXC() + 1; i++) {

--- a/src/main/java/vimicalc/view/simpleRect.java
+++ b/src/main/java/vimicalc/view/simpleRect.java
@@ -1,14 +1,14 @@
 package vimicalc.view;
 
 import javafx.scene.canvas.GraphicsContext;
-import javafx.scene.paint.Color;
+import javafx.scene.paint.Paint;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * Abstract base class for all rectangular UI components drawn on the canvas.
  *
  * <p>Provides position ({@code x}, {@code y}), dimensions ({@code w}, {@code h}),
- * and background color ({@code c}). Subclasses override {@link #draw(GraphicsContext)}
+ * and background fill ({@code c}). Subclasses override {@link #draw(GraphicsContext)}
  * to render their specific content on top of the filled rectangle.</p>
  */
 public abstract class simpleRect {
@@ -20,19 +20,19 @@ public abstract class simpleRect {
     protected int w;
     /** The height in pixels. */
     protected int h;
-    /** The fill color. */
-    protected Color c;
+    /** The background fill (a solid color or a gradient). */
+    protected Paint c;
 
     /**
-     * Creates a new rectangle at the given position with the given size and color.
+     * Creates a new rectangle at the given position with the given size and fill.
      *
      * @param x the x-coordinate of the top-left corner (pixels)
      * @param y the y-coordinate of the top-left corner (pixels)
      * @param w the width (pixels)
      * @param h the height (pixels)
-     * @param c the fill color
+     * @param c the background fill
      */
-    public simpleRect(int x, int y, int w, int h, Color c) {
+    public simpleRect(int x, int y, int w, int h, Paint c) {
         this.x = x;
         this.y = y;
         this.w = w;
@@ -41,7 +41,7 @@ public abstract class simpleRect {
     }
 
     /**
-     * Fills this rectangle on the canvas with its background color.
+     * Fills this rectangle on the canvas with its background fill.
      * Subclasses should call {@code super.draw(gc)} before rendering their content.
      *
      * @param gc the graphics context to draw on
@@ -76,13 +76,13 @@ public abstract class simpleRect {
         return h;
     }
 
-    /** @return the fill color */
-    public Color getC() {
+    /** @return the background fill */
+    public Paint getC() {
         return c;
     }
 
-    /** @param c the new fill color */
-    public void setC(Color c) {
+    /** @param c the new background fill */
+    public void setC(Paint c) {
         this.c = c;
     }
 

--- a/src/main/resources/vimicalc/GUI.fxml
+++ b/src/main/resources/vimicalc/GUI.fxml
@@ -8,31 +8,31 @@
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 
-<VBox prefHeight="600.0" prefWidth="900.0" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1" fx:controller="vimicalc.controller.Controller">
+<VBox prefHeight="600.0" prefWidth="900.0" stylesheets="@theme.css" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1" fx:controller="vimicalc.controller.Controller">
   <children>
     <StackPane fx:id="canvasStack" minHeight="0.0" minWidth="0.0" prefHeight="548.0" prefWidth="900.0" VBox.vgrow="ALWAYS">
       <children>
         <Canvas fx:id="canvas" height="548.0" width="900.0" />
         <Pane fx:id="overlayPane" mouseTransparent="true" pickOnBounds="false" prefHeight="548.0" prefWidth="900.0">
           <children>
-            <Label fx:id="keyStrokeLabel" alignment="CENTER" focusTraversable="false" layoutX="0.0" layoutY="0.0" prefHeight="24.0" prefWidth="48.0" style="-fx-background-color: lightgreen; -fx-text-fill: blue;" text="" />
-            <Label fx:id="helpLabel" alignment="TOP_LEFT" focusTraversable="false" layoutX="30.0" layoutY="30.0" prefHeight="480.0" prefWidth="740.0" style="-fx-background-color: lightyellow; -fx-text-fill: black; -fx-padding: 10;" text="" visible="false" wrapText="true" />
+            <Label fx:id="keyStrokeLabel" alignment="CENTER" focusTraversable="false" layoutX="0.0" layoutY="0.0" prefHeight="24.0" prefWidth="48.0" styleClass="keystroke-chip" text="" visible="false" />
+            <Label fx:id="helpLabel" alignment="TOP_LEFT" focusTraversable="false" layoutX="30.0" layoutY="30.0" prefHeight="480.0" prefWidth="740.0" styleClass="help-overlay" text="" visible="false" wrapText="true" />
           </children>
         </Pane>
       </children>
     </StackPane>
-    <HBox fx:id="statusRow" alignment="CENTER_LEFT" prefHeight="28.0" prefWidth="900.0" style="-fx-background-color: lightgreen;">
+    <HBox fx:id="statusRow" alignment="CENTER_LEFT" prefHeight="28.0" prefWidth="900.0" styleClass="status-row">
       <children>
-        <Label fx:id="statusLabel" focusTraversable="false" style="-fx-text-fill: blue;" text=" [NORMAL]  --new_file--" />
+        <Label fx:id="statusLabel" focusTraversable="false" styleClass="status-label" text=" [NORMAL]  --new_file--" />
         <Region HBox.hgrow="ALWAYS" />
-        <Label fx:id="coordsLabel" focusTraversable="false" style="-fx-text-fill: blue; -fx-padding: 0 4 0 0;" text="B2" />
+        <Label fx:id="coordsLabel" focusTraversable="false" styleClass="coords-label" text="B2" />
       </children>
     </HBox>
-    <HBox fx:id="infoRow" alignment="CENTER_LEFT" prefHeight="24.0" prefWidth="900.0" style="-fx-background-color: white;">
+    <HBox fx:id="infoRow" alignment="CENTER_LEFT" prefHeight="24.0" prefWidth="900.0" styleClass="info-row">
       <children>
-        <Label fx:id="infoLabel" focusTraversable="false" style="-fx-padding: 0 0 0 2;" text="(=I)" />
+        <Label fx:id="infoLabel" focusTraversable="false" styleClass="info-label" text="(=I)" />
         <Region HBox.hgrow="ALWAYS" />
-        <Label fx:id="exprLabel" focusTraversable="false" style="-fx-padding: 0 4 0 0;" text="" />
+        <Label fx:id="exprLabel" focusTraversable="false" styleClass="expr-label" text="" />
       </children>
     </HBox>
   </children>

--- a/src/main/resources/vimicalc/theme.css
+++ b/src/main/resources/vimicalc/theme.css
@@ -1,0 +1,70 @@
+/*
+ * VimiCalc chrome theme — Modena-style depth on a neutral gray-blue palette.
+ *
+ * The canvas-side counterparts of these colors (headers, gridlines, selector)
+ * live in view/Defaults.java; keep the two in sync when changing shades.
+ */
+
+/* Status bar: top-lit gradient body under a hairline border and an inner
+ * highlight, the same layered-background-insets idiom Modena uses. */
+.status-row {
+    -fx-background-color:
+        #a9b1ba,
+        linear-gradient(to bottom, #ffffff, #f4f6f8),
+        linear-gradient(to bottom, #f4f6f8, #dfe3e8);
+    -fx-background-insets: 0, 1 0 0 0, 2 0 0 0;
+}
+
+.status-label {
+    -fx-text-fill: #333333;
+    -fx-font-weight: bold;
+}
+
+.coords-label {
+    -fx-text-fill: #007ac1;
+    -fx-font-weight: bold;
+    -fx-padding: 0 4 0 0;
+}
+
+/* Info bar: near-white gradient with a softer hairline above it. */
+.info-row {
+    -fx-background-color:
+        #c3cad2,
+        linear-gradient(to bottom, #ffffff, #f4f6f8);
+    -fx-background-insets: 0, 1 0 0 0;
+}
+
+.info-label {
+    -fx-text-fill: #222222;
+    -fx-padding: 0 0 0 2;
+}
+
+.expr-label {
+    -fx-text-fill: #222222;
+    -fx-padding: 0 4 0 0;
+}
+
+/* Keystroke chip: floats over the header corner block. Hidden while empty
+ * (see KeyStrokeCell), so the pill only appears once a key is pressed. */
+.keystroke-chip {
+    -fx-background-color:
+        #a9b1ba,
+        linear-gradient(to bottom, #f4f6f8, #dfe3e8);
+    -fx-background-insets: 0, 1;
+    -fx-background-radius: 4, 3;
+    -fx-text-fill: #007ac1;
+    -fx-font-weight: bold;
+    -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.25), 4, 0, 0, 1);
+}
+
+/* Help overlay: floating card with a border and a soft shadow. */
+.help-overlay {
+    -fx-background-color:
+        #a9b1ba,
+        linear-gradient(to bottom, #fdfefe, #f4f6f8);
+    -fx-background-insets: 0, 1;
+    -fx-background-radius: 8, 7;
+    -fx-text-fill: #222222;
+    -fx-padding: 12;
+    -fx-effect: dropshadow(gaussian, rgba(0, 0, 0, 0.35), 16, 0, 0, 4);
+}


### PR DESCRIPTION
## What

Makes the GUI look less flat by adopting JavaFX's native (Modena) visual language on a neutral gray-blue palette, keeping the existing cyan-blue as the single accent color.

### Chrome (new `theme.css`, replaces all inline FXML styles)
- **Status bar**: top-lit gradient body under a hairline border and inner highlight (Modena's layered background-insets idiom); bold dark mode/filename text, accent-colored coords.
- **Info bar**: near-white gradient with a softer hairline above it.
- **Keystroke chip**: rounded, bordered, drop-shadowed pill that now hides while empty instead of sitting as a flat green block.
- **Help menu**: floating card with rounded corners, border, and a soft shadow.

### Canvas
- **Column/row headers**: flat `LIGHTBLUE` → top-/left-lit gradients with inset hairline separators between labels and a border line where the headers meet the grid; the previously unpainted top-left corner block is now part of the header surface.
- **Cell selector**: solid saturated cyan → light selection tint with a 2px accent border (normal and merged cells).
- **VISUAL ranges**: same tint, so range selection matches the cursor.
- **Gridlines**: `LIGHTGRAY` → a slightly blue-shifted gray matching the palette.

All shades live as Javadoc'd constants in `view/Defaults.java`, mirrored in `theme.css`. `simpleRect`'s fill widened `Color` → `Paint` so headers can take gradients (its accessors were unused outside the class).

## Testing

- Full suite green headless (TestFX Monocle init script).
- Visual verification via a throwaway TestFX probe capturing `scene.snapshot` PNGs: NORMAL cursor, VISUAL range, INSERT editing, 133% zoom, `:gridlines` off, help overlay, and a `:cellColor`-formatted cell all render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JSoXPdzQyovRTsgaNUkbsd