### PR TITLE
Fix tokenizer edge cases: empty input, repeated spaces

### DIFF
--- a/src/main/java/vimicalc/model/Tokenizer.java
+++ b/src/main/java/vimicalc/model/Tokenizer.java
@@ -9,14 +9,8 @@ import static vimicalc.utils.Conversions.isNumber;
  *
  * <p>Splits on spaces; numeric tokens become {@linkplain Token.Type#LITERAL
  * literals}, everything else becomes {@linkplain Token.Type#SYMBOL symbols}.
- * Parentheses are stripped.</p>
- *
- * <p><b>Known quirks</b> (pinned by tests; fixing them is separate work):</p>
- * <ul>
- *   <li>Empty input throws {@link ArrayIndexOutOfBoundsException} (backing array
- *       is sized from the pre-padding text length).</li>
- *   <li>Consecutive spaces produce empty-string symbol tokens.</li>
- * </ul>
+ * Parentheses are stripped. Runs of spaces produce no tokens; empty input
+ * yields an empty array.</p>
  */
 final class Tokenizer {
     private Tokenizer() {}
@@ -36,10 +30,13 @@ final class Tokenizer {
         for (int i = 0; i < txt.length(); i++) {
             if (txt.charAt(i) == '(' || txt.charAt(i) == ')') continue;
             if (txt.charAt(i) == ' ') {
-                if (isNumber(arg))
-                    argsLong[argsLength++] = new Token(Double.parseDouble(arg));
-                else argsLong[argsLength++] = new Token(arg);
-                arg = "";
+                if (!arg.isEmpty()) {
+                    if (isNumber(arg))
+                        argsLong[argsLength++] = new Token(Double.parseDouble(arg));
+                    else
+                        argsLong[argsLength++] = new Token(arg);
+                    arg = "";
+                }
                 continue;
             }
             arg += txt.charAt(i);

--- a/src/test/java/vimicalc/model/TokenizerTest.java
+++ b/src/test/java/vimicalc/model/TokenizerTest.java
@@ -46,31 +46,45 @@ class TokenizerTest {
         }
     }
 
-    /**
-     * Known quirks of the current tokenizer, pinned as-is.
-     * Fixing them is a separate sub-issue of #58.
-     */
     @Nested
-    class KnownQuirks {
+    class EdgeCases {
         @Test
-        void emptyInputThrowsArrayIndexOutOfBoundsException() {
-            // Backing array is sized from pre-padding length (0), then a space is
-            // appended and produces one token write past the array bound.
-            assertThrows(ArrayIndexOutOfBoundsException.class,
-                () -> Tokenizer.tokenize(""));
+        void emptyInputReturnsEmptyArray() {
+            Token[] result = Tokenizer.tokenize("");
+            assertEquals(0, result.length);
         }
 
         @Test
-        void consecutiveSpacesProduceEmptyStringSymbolTokens() {
+        void consecutiveSpacesDoNotProduceTokens() {
             Token[] result = Tokenizer.tokenize("3  4");
-            // "3" + empty (from double space) + "4"
-            assertEquals(3, result.length);
+            assertEquals(2, result.length);
             assertTrue(result[0].isLiteral());
             assertEquals(3.0, result[0].getVal());
-            assertTrue(result[1].isSymbol());
-            assertEquals("", result[1].getSymbol());
-            assertTrue(result[2].isLiteral());
-            assertEquals(4.0, result[2].getVal());
+            assertTrue(result[1].isLiteral());
+            assertEquals(4.0, result[1].getVal());
+        }
+
+        @Test
+        void leadingAndTrailingSpacesIgnored() {
+            Token[] result = Tokenizer.tokenize("  3 4  ");
+            assertEquals(2, result.length);
+            assertEquals(3.0, result[0].getVal());
+            assertEquals(4.0, result[1].getVal());
+        }
+
+        @Test
+        void whitespaceOnlyReturnsEmptyArray() {
+            Token[] result = Tokenizer.tokenize("   ");
+            assertEquals(0, result.length);
+        }
+
+        @Test
+        void doubleSpacesInExpression() {
+            Token[] result = Tokenizer.tokenize("3  5 +");
+            assertEquals(3, result.length);
+            assertEquals(3.0, result[0].getVal());
+            assertEquals(5.0, result[1].getVal());
+            assertEquals("+", result[2].getSymbol());
         }
     }
 }


### PR DESCRIPTION
## Summary

- Fix `Tokenizer.tokenize` to skip empty fragments on space flush, so empty input returns an empty token array instead of throwing `ArrayIndexOutOfBoundsException`, and consecutive/leading/trailing spaces no longer produce empty-string symbol tokens.
- Replace quirk-pinning tests in `TokenizerTest` with corrected-behavior coverage (empty input, double spaces, leading/trailing whitespace, whitespace-only, expression with double spaces).
- Update tokenizer class Javadoc to document the intended whitespace behavior.

Part 4 of #58. Depends only on the Tokenizer extraction already merged in #64.

Closes #62

## Test plan

- [x] `./gradlew test --tests 'vimicalc.model.*' --tests 'vimicalc.controller.*' --tests 'vimicalc.utils.*'` green
- [x] `TokenizerTest` covers empty input, consecutive spaces, leading/trailing spaces, whitespace-only, and `3  5 +`
- [x] Manual (optional): `./gradlew run`, enter formula `3  5 +` and confirm it evaluates instead of erroring

🤖 Generated with Grok Build