### PR TITLE
Registry-based Command dispatch: derive completion, central arity, empty-input guard (#63, #67)

### DIFF
--- a/src/main/java/vimicalc/controller/Controller.java
+++ b/src/main/java/vimicalc/controller/Controller.java
@@ -293,7 +293,6 @@ public class Controller implements Initializable {
                         );
                         sheet.addCell(c);
                         goTo(c.xCoord(), c.yCoord());
-                        command.commandExists = true;
                     } catch (Exception e) {
                         infoBar.setInfobarTxt(e.getMessage());
                     }

--- a/src/main/java/vimicalc/model/Command.java
+++ b/src/main/java/vimicalc/model/Command.java
@@ -5,9 +5,6 @@ import vimicalc.view.Formatting;
 
 import java.util.List;
 
-import static vimicalc.view.Defaults.DEFAULT_FONT_SIZE;
-import static vimicalc.view.Defaults.DEFAULT_ZOOM;
-
 /**
  * Executes colon commands entered in COMMAND mode (e.g. {@code :w}, {@code :q},
  * {@code :cellColor red}).
@@ -32,6 +29,10 @@ import static vimicalc.view.Defaults.DEFAULT_ZOOM;
  *   <li>{@code :gridlines} — toggle cell gridlines on and off</li>
  * </ul>
  *
+ * <p>Each command is defined once in {@link CommandRegistry}, which is the source of
+ * record for command names, argument counts, and usage strings; the list above is a
+ * human-readable summary and {@link #COMMAND_NAMES} is derived from the registry.</p>
+ *
  * <p>Color arguments accept the built-in names (red, green, blue, white, black,
  * gray, lGray, dGray, vLGray), any CSS color name (e.g. crimson, teal), or a
  * hex value like {@code #ff8800}. An empty or unrecognized color resets to the
@@ -39,15 +40,11 @@ import static vimicalc.view.Defaults.DEFAULT_ZOOM;
  */
 public class Command {
     /**
-     * Every recognized command name, in the order of the class Javadoc list.
-     * Used for COMMAND-mode autocompletion; keep in sync with the switch in
-     * {@link #execute(Sheet)} (enforced by {@code CommandTest}).
+     * Every recognized command name and alias, in registration order, derived from
+     * {@link CommandRegistry}. Used for COMMAND-mode autocompletion. Because it is
+     * derived, a command cannot exist without also being completable.
      */
-    public static final List<String> COMMAND_NAMES = List.of(
-        "h", "help", "?", "e", "w", "wq", "q", "resCol", "resRow", "purgeDeps",
-        "cellColor", "txtColor", "boldTxt", "italicTxt", "fontSize", "fontWeight",
-        "zoom", "gridlines"
-    );
+    public static final List<String> COMMAND_NAMES = CommandRegistry.names();
 
     /** Column index of the cell this command is associated with. */
     private final int xC;
@@ -88,23 +85,6 @@ public class Command {
     }
 
     /**
-     * Set to {@code false} after evaluation if the entered command was not recognized.
-     * Starts as {@code true} and is reset to {@code true} at the beginning of every
-     * {@link #execute(Sheet)} call.
-     */
-    public boolean commandExists = true;
-
-    /** The result of the last {@link #execute(Sheet)} call. */
-    private CommandResult commandResult = CommandResult.NONE;
-
-    /**
-     * Returns the result of the last execution (e.g. {@link CommandResult#HELP}).
-     */
-    public CommandResult getCommandResult() {
-        return commandResult;
-    }
-
-    /**
      * Tokenises the command text and dispatches it against the given sheet.
      *
      * @param sheet the sheet context
@@ -123,7 +103,7 @@ public class Command {
      * @param command the lexed command tokens (path in {@code command[1]})
      * @throws Exception if the file cannot be read
      */
-    public void readFile(Sheet sheet, Token[] command) throws Exception {
+    static void readFile(Sheet sheet, Token[] command) throws Exception {
         sheet.readFile(command[1].getSymbol());
     }
 
@@ -134,87 +114,27 @@ public class Command {
      * @param command the lexed command tokens (optional path in {@code command[1]})
      * @throws Exception if the file cannot be written
      */
-    public void writeFile(Sheet sheet, Token[] command) throws Exception {
+    static void writeFile(Sheet sheet, Token[] command) throws Exception {
         if (command.length == 1) sheet.writeFile();
         else sheet.writeFile(command[1].getSymbol());
     }
 
     private CommandResult execute(Token[] command, Sheet sheet) throws Exception {
-        commandExists = true;
-        commandResult = CommandResult.NONE;
-        switch (command[0].getSymbol()) {
-            case "h", "help", "?" -> commandResult = CommandResult.HELP;
-            case "e" -> readFile(sheet, command);
-            case "resCol" -> sheet.getPositions().applyOffset(
-                new int[]{xC, (int) command[1].getVal()},
-                true
-            );
-            case "resRow" -> sheet.getPositions().applyOffset(
-                new int[]{yC, (int) command[1].getVal()},
-                false
-            );
-            case "purgeDeps" -> sheet.purgeDependencies();
-            case "w" -> writeFile(sheet, command);
-            case "wq" -> {
-                try {
-                    writeFile(sheet, command);
-                } catch (Exception ignored) {}
-                commandResult = CommandResult.QUIT;
-            }
-            case "q" -> commandResult = CommandResult.QUIT;
-            case "cellColor" -> {
-                if (command.length == 1) cellColor("", sheet);
-                else cellColor(command[1].getSymbol(), sheet);
-            }
-            case "txtColor" -> {
-                if (command.length == 1) txtColor("", sheet);
-                else txtColor(command[1].getSymbol(), sheet);
-            }
-            case "boldTxt" -> boldTxt(sheet);
-            case "italicTxt" -> italicTxt(sheet);
-            case "fontSize" -> {
-                if (command.length == 1) fontSize(DEFAULT_FONT_SIZE, sheet);
-                else {
-                    if (command[1].isSymbol() ||
-                        command[1].getVal() < 4 || command[1].getVal() > 200)
-                        throw new Exception("fontSize expects a size between 4 and 200.");
-                    fontSize((int) command[1].getVal(), sheet);
-                }
-            }
-            // Global view toggle — like :zoom, ignores xC/yC.
-            case "gridlines" -> sheet.getPositions().toggleGridlines();
-            case "zoom" -> {
-                // Global view zoom — unlike :resCol/:fontSize, ignores xC/yC.
-                if (command.length == 1) sheet.getPositions().setZoom(DEFAULT_ZOOM);
-                else {
-                    if (command[1].isSymbol() ||
-                        command[1].getVal() < 25 || command[1].getVal() > 400)
-                        throw new Exception("zoom expects a percentage between 25 and 400.");
-                    sheet.getPositions().setZoom(command[1].getVal() / 100);
-                }
-            }
-            case "fontWeight" -> {
-                if (command.length == 1) fontWeight("normal", sheet);
-                else if (!command[1].isSymbol()) {
-                    if (command[1].getVal() < 100 || command[1].getVal() > 900)
-                        throw new Exception("fontWeight expects bold, normal, or a weight between 100 and 900.");
-                    fontWeight(String.valueOf((int) command[1].getVal()), sheet);
-                }
-                else {
-                    if (!command[1].getSymbol().equals("bold") && !command[1].getSymbol().equals("normal"))
-                        throw new Exception("fontWeight expects bold, normal, or a weight between 100 and 900.");
-                    fontWeight(command[1].getSymbol(), sheet);
-                }
-            }
-            default -> {
-                commandExists = false;
-                throw new Exception("Command \"" + command[0].getSymbol() + "\" doesn't exist.");
-            }
-        }
-        return commandResult;
+        // Bare ":" (or ":" + only spaces) tokenises to nothing — do nothing, like Vim.
+        if (command.length == 0) return CommandResult.NONE;
+
+        CommandRegistry.CommandDef def = CommandRegistry.lookup(command[0].getSymbol());
+        if (def == null)
+            throw new Exception("Command \"" + command[0].getSymbol() + "\" doesn't exist.");
+
+        int argc = command.length - 1;
+        if (argc < def.minArgs() || argc > def.maxArgs())
+            throw new Exception("Usage: " + def.usage());
+
+        return def.handler().run(command, sheet, xC, yC);
     }
 
-    private void cellColor(@NotNull String color, Sheet sheet) {
+    static void cellColor(@NotNull String color, Sheet sheet, int xC, int yC) {
         Formatting f;
         System.out.println("Executing command 'cellColor'...");
         f = sheet.findFormatting(xC, yC);
@@ -230,7 +150,7 @@ public class Command {
         System.out.println("Cell formats: " + sheet.findFormatting(xC, yC));
     }
 
-    private void txtColor(@NotNull String color, Sheet sheet) {
+    static void txtColor(@NotNull String color, Sheet sheet, int xC, int yC) {
         Formatting f;
         System.out.println("Executing command 'txtColor'...");
         f = sheet.findFormatting(xC, yC);
@@ -246,7 +166,7 @@ public class Command {
         System.out.println("Cell formats: " + sheet.findFormatting(xC, yC));
     }
 
-    private void boldTxt(@NotNull Sheet sheet) {
+    static void boldTxt(@NotNull Sheet sheet, int xC, int yC) {
         Formatting f = sheet.findFormatting(xC, yC);
         if (f == null) {
             f = new Formatting();
@@ -258,7 +178,7 @@ public class Command {
         } else f.setFontWeight("bold");
     }
 
-    private void italicTxt(@NotNull Sheet sheet) {
+    static void italicTxt(@NotNull Sheet sheet, int xC, int yC) {
         Formatting f = sheet.findFormatting(xC, yC);
         if (f == null) {
             f = new Formatting();
@@ -270,7 +190,7 @@ public class Command {
         } else f.setFontPosture("italic");
     }
 
-    private void fontSize(int size, @NotNull Sheet sheet) {
+    static void fontSize(int size, @NotNull Sheet sheet, int xC, int yC) {
         Formatting f = sheet.findFormatting(xC, yC);
         if (f == null) {
             f = new Formatting();
@@ -281,7 +201,7 @@ public class Command {
         if (f.isDefault()) sheet.deleteFormatting(xC, yC);
     }
 
-    private void fontWeight(@NotNull String weight, @NotNull Sheet sheet) {
+    static void fontWeight(@NotNull String weight, @NotNull Sheet sheet, int xC, int yC) {
         Formatting f = sheet.findFormatting(xC, yC);
         if (f == null) {
             f = new Formatting();

--- a/src/main/java/vimicalc/model/CommandRegistry.java
+++ b/src/main/java/vimicalc/model/CommandRegistry.java
@@ -1,0 +1,184 @@
+package vimicalc.model;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+
+import static vimicalc.view.Defaults.DEFAULT_FONT_SIZE;
+import static vimicalc.view.Defaults.DEFAULT_ZOOM;
+
+/**
+ * The single source of truth for colon commands ({@code :w}, {@code :cellColor red}, …).
+ *
+ * <p>Each command is described once by a {@link CommandDef}: its canonical name, any
+ * aliases, its allowed argument count, a usage string, and the {@link CommandHandler}
+ * that runs it. Everything else the app needs about commands is <b>derived</b> from
+ * these definitions:</p>
+ *
+ * <ul>
+ *   <li>{@link Command#COMMAND_NAMES} (COMMAND-mode TAB completion) is {@link #names()},
+ *       so a command cannot exist without also being completable — the drift that caused
+ *       issue #57 (a switch case with no completion entry) is impossible by construction.</li>
+ *   <li>{@link Command#execute(Sheet)} dispatches via {@link #lookup(String)} and enforces
+ *       arity centrally before invoking the handler.</li>
+ * </ul>
+ *
+ * <p>Registration order matches the historical {@code COMMAND_NAMES} order. Registering a
+ * name or alias twice throws immediately at class-load time.</p>
+ */
+final class CommandRegistry {
+    private CommandRegistry() {}
+
+    /** Runs a command; returns the controller side-effect signal (usually {@link CommandResult#NONE}). */
+    @FunctionalInterface
+    interface CommandHandler {
+        /**
+         * @param args  the lexed command tokens; {@code args[0]} is the command name,
+         *              {@code args[1..]} its arguments
+         * @param sheet the sheet context
+         * @param xC    the column index of the current cell
+         * @param yC    the row index of the current cell
+         */
+        CommandResult run(Token[] args, Sheet sheet, int xC, int yC) throws Exception;
+    }
+
+    /**
+     * A command definition.
+     *
+     * @param name    the canonical command name (e.g. {@code "cellColor"})
+     * @param aliases alternate names (e.g. {@code ["help", "?"]} for {@code "h"}); usually empty
+     * @param minArgs the minimum number of arguments <b>after</b> the command name
+     * @param maxArgs the maximum number of arguments <b>after</b> the command name
+     * @param usage   a usage string, beginning with {@code :} + {@link #name()}
+     * @param handler the behavior
+     */
+    record CommandDef(String name, List<String> aliases, int minArgs, int maxArgs,
+                      String usage, CommandHandler handler) {}
+
+    /** Every name and alias mapped to its definition. Iteration order is registration order. */
+    private static final LinkedHashMap<String, CommandDef> REGISTRY = new LinkedHashMap<>();
+    /** Every name and alias, flattened in registration order — the value of {@link #names()}. */
+    private static final List<String> NAMES = new ArrayList<>();
+
+    private static void register(CommandDef def) {
+        registerName(def.name(), def);
+        for (String alias : def.aliases()) registerName(alias, def);
+    }
+
+    private static void registerName(String name, CommandDef def) {
+        if (REGISTRY.putIfAbsent(name, def) != null)
+            throw new IllegalStateException("Duplicate command name or alias: " + name);
+        NAMES.add(name);
+    }
+
+    /** Returns the definition for {@code name} (a canonical name or alias), or {@code null} if none. */
+    static CommandDef lookup(String name) {
+        return REGISTRY.get(name);
+    }
+
+    /** Returns every command name and alias, flattened in registration order. */
+    static List<String> names() {
+        return List.copyOf(NAMES);
+    }
+
+    static {
+        register(new CommandDef("h", List.of("help", "?"), 0, 0,
+            ":h, :help, :? — open the help menu",
+            (args, sheet, xC, yC) -> CommandResult.HELP));
+        register(new CommandDef("e", List.of(), 1, 1,
+            ":e <path> — open/read a .json file",
+            (args, sheet, xC, yC) -> { Command.readFile(sheet, args); return CommandResult.NONE; }));
+        register(new CommandDef("w", List.of(), 0, 1,
+            ":w [path] — save the current sheet",
+            (args, sheet, xC, yC) -> { Command.writeFile(sheet, args); return CommandResult.NONE; }));
+        register(new CommandDef("wq", List.of(), 0, 1,
+            ":wq [path] — save and quit",
+            (args, sheet, xC, yC) -> {
+                try {
+                    Command.writeFile(sheet, args);
+                } catch (Exception ignored) {}
+                return CommandResult.QUIT;
+            }));
+        register(new CommandDef("q", List.of(), 0, 0,
+            ":q — quit without saving",
+            (args, sheet, xC, yC) -> CommandResult.QUIT));
+        register(new CommandDef("resCol", List.of(), 1, 1,
+            ":resCol <offset> — resize the current column",
+            (args, sheet, xC, yC) -> {
+                sheet.getPositions().applyOffset(new int[]{xC, (int) args[1].getVal()}, true);
+                return CommandResult.NONE;
+            }));
+        register(new CommandDef("resRow", List.of(), 1, 1,
+            ":resRow <offset> — resize the current row",
+            (args, sheet, xC, yC) -> {
+                sheet.getPositions().applyOffset(new int[]{yC, (int) args[1].getVal()}, false);
+                return CommandResult.NONE;
+            }));
+        register(new CommandDef("purgeDeps", List.of(), 0, 0,
+            ":purgeDeps — clear all formula dependencies",
+            (args, sheet, xC, yC) -> { sheet.purgeDependencies(); return CommandResult.NONE; }));
+        register(new CommandDef("cellColor", List.of(), 0, 1,
+            ":cellColor [color] — set the cell background color",
+            (args, sheet, xC, yC) -> {
+                Command.cellColor(args.length == 1 ? "" : args[1].getSymbol(), sheet, xC, yC);
+                return CommandResult.NONE;
+            }));
+        register(new CommandDef("txtColor", List.of(), 0, 1,
+            ":txtColor [color] — set the cell text color",
+            (args, sheet, xC, yC) -> {
+                Command.txtColor(args.length == 1 ? "" : args[1].getSymbol(), sheet, xC, yC);
+                return CommandResult.NONE;
+            }));
+        register(new CommandDef("boldTxt", List.of(), 0, 0,
+            ":boldTxt — toggle bold text on the current cell",
+            (args, sheet, xC, yC) -> { Command.boldTxt(sheet, xC, yC); return CommandResult.NONE; }));
+        register(new CommandDef("italicTxt", List.of(), 0, 0,
+            ":italicTxt — toggle italic text on the current cell",
+            (args, sheet, xC, yC) -> { Command.italicTxt(sheet, xC, yC); return CommandResult.NONE; }));
+        register(new CommandDef("fontSize", List.of(), 0, 1,
+            ":fontSize [px] — set the font size (no argument resets to default)",
+            (args, sheet, xC, yC) -> {
+                if (args.length == 1) Command.fontSize(DEFAULT_FONT_SIZE, sheet, xC, yC);
+                else {
+                    if (args[1].isSymbol() || args[1].getVal() < 4 || args[1].getVal() > 200)
+                        throw new Exception("fontSize expects a size between 4 and 200.");
+                    Command.fontSize((int) args[1].getVal(), sheet, xC, yC);
+                }
+                return CommandResult.NONE;
+            }));
+        register(new CommandDef("fontWeight", List.of(), 0, 1,
+            ":fontWeight [bold|normal|100-900] — set the font weight (no argument resets to normal)",
+            (args, sheet, xC, yC) -> {
+                if (args.length == 1) Command.fontWeight("normal", sheet, xC, yC);
+                else if (!args[1].isSymbol()) {
+                    if (args[1].getVal() < 100 || args[1].getVal() > 900)
+                        throw new Exception("fontWeight expects bold, normal, or a weight between 100 and 900.");
+                    Command.fontWeight(String.valueOf((int) args[1].getVal()), sheet, xC, yC);
+                } else {
+                    if (!args[1].getSymbol().equals("bold") && !args[1].getSymbol().equals("normal"))
+                        throw new Exception("fontWeight expects bold, normal, or a weight between 100 and 900.");
+                    Command.fontWeight(args[1].getSymbol(), sheet, xC, yC);
+                }
+                return CommandResult.NONE;
+            }));
+        register(new CommandDef("zoom", List.of(), 0, 1,
+            ":zoom [25-400] — set the view zoom percentage (no argument resets to 100%)",
+            (args, sheet, xC, yC) -> {
+                // Global view zoom — unlike :resCol/:fontSize, ignores xC/yC.
+                if (args.length == 1) sheet.getPositions().setZoom(DEFAULT_ZOOM);
+                else {
+                    if (args[1].isSymbol() || args[1].getVal() < 25 || args[1].getVal() > 400)
+                        throw new Exception("zoom expects a percentage between 25 and 400.");
+                    sheet.getPositions().setZoom(args[1].getVal() / 100);
+                }
+                return CommandResult.NONE;
+            }));
+        register(new CommandDef("gridlines", List.of(), 0, 0,
+            ":gridlines — toggle cell gridlines on and off",
+            (args, sheet, xC, yC) -> {
+                // Global view toggle — like :zoom, ignores xC/yC.
+                sheet.getPositions().toggleGridlines();
+                return CommandResult.NONE;
+            }));
+    }
+}

--- a/src/test/java/vimicalc/model/CommandTest.java
+++ b/src/test/java/vimicalc/model/CommandTest.java
@@ -3,12 +3,11 @@ package vimicalc.model;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 import vimicalc.view.Formatting;
 import vimicalc.view.Positions;
 
-import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -203,33 +202,50 @@ class CommandTest {
     @Nested
     class UnknownCommandTests {
         @Test
-        void unknownCommandThrowsAndFlags() {
+        void unknownCommandThrowsDoesntExist() {
             Command c = new Command("frobnicate", 1, 1);
-            assertThrows(Exception.class, () -> c.execute(sheet));
-            assertFalse(c.commandExists);
+            Exception e = assertThrows(Exception.class, () -> c.execute(sheet));
+            assertTrue(e.getMessage().contains("doesn't exist"));
         }
     }
 
-    // ── COMMAND_NAMES (autocompletion) ──
+    // ── Registry dispatch (issue #63 / #67) ──
 
     @Nested
-    class CommandNamesTests {
-        @TempDir
-        Path tempDir;
+    class RegistryTests {
+        @Test
+        void commandNamesAreDerivedFromRegistryWithoutDuplicates() {
+            // Loading Command runs the registry's static init; a duplicate
+            // name/alias would throw there before we ever get here.
+            assertEquals(CommandRegistry.names(), Command.COMMAND_NAMES);
+            assertEquals(Command.COMMAND_NAMES.size(),
+                Set.copyOf(Command.COMMAND_NAMES).size(),
+                "COMMAND_NAMES must not contain duplicate names or aliases");
+        }
 
         @Test
-        void everyListedNameIsRecognizedByExecute() {
+        void everyUsageStringStartsWithItsCommandName() {
             for (String name : Command.COMMAND_NAMES) {
-                // The tempDir argument keeps :w / :wq from writing into the
-                // working directory; commands that reject it still count as
-                // recognized (only the default branch clears commandExists).
-                Command c = new Command(name + ' ' + tempDir.resolve("out"), 2, 3);
-                try {
-                    c.execute(sheet);
-                } catch (Exception ignored) {}
-                assertTrue(c.commandExists,
-                    "\"" + name + "\" is in COMMAND_NAMES but not in the execute switch");
+                CommandRegistry.CommandDef def = CommandRegistry.lookup(name);
+                assertNotNull(def, "\"" + name + "\" has no registry entry");
+                assertTrue(def.usage().startsWith(":" + def.name()),
+                    "usage for \"" + def.name() + "\" should start with \":" + def.name()
+                        + "\" but was: " + def.usage());
             }
+        }
+
+        @Test
+        void missingRequiredArgumentReportsUsageInsteadOfCrashing() {
+            Exception e = assertThrows(Exception.class, () -> run("e"));
+            assertTrue(e.getMessage().contains("e"));
+            Exception r = assertThrows(Exception.class, () -> run("resCol"));
+            assertTrue(r.getMessage().contains("resCol"));
+        }
+
+        @Test
+        void blankInputIsANoOp() throws Exception {
+            assertEquals(CommandResult.NONE, new Command("", 2, 3).execute(sheet));
+            assertEquals(CommandResult.NONE, new Command("   ", 2, 3).execute(sheet));
         }
     }
 }


### PR DESCRIPTION
## What & why

`model/Command.java` defined every colon command in up to four hand-synced places (switch case, `COMMAND_NAMES`, class Javadoc, scattered arg validation). Issue #57 was exactly this drift: `:gridlines` had a switch case but no `COMMAND_NAMES` entry, so it worked when typed in full but never TAB-completed — and the existing one-directional guard couldn't catch a *missing* list entry.

This makes a **command registry the single source of truth** and derives everything else from it.

## Changes

- **New `model/CommandRegistry.java`** — each command is one `CommandDef` (canonical name, aliases, min/max args, usage, handler). Registration runs once in a static initializer, in the historical order; a duplicate name/alias throws immediately.
- **`Command.COMMAND_NAMES` is now derived** (`CommandRegistry.names()`), so a command cannot exist without also being TAB-completable — the #57 class of drift is impossible by construction.
- **Dispatch** (`Command.execute`) replaces the switch with: empty-token guard → registry lookup → central arity check → handler invocation.
  - **#67**: bare `:` (or `:` + only spaces) returns `NONE` silently instead of a caught `ArrayIndexOutOfBoundsException` shown as a raw JDK message.
  - **Arity**: `:e` / `:resCol` with no argument now report a usage message instead of crashing with `AIOOBE`.
- Retired the now-unused `commandExists` / `commandResult` fields and `getCommandResult()`. The format/file helpers became `static` (taking `xC`/`yC`) so the registry's handler lambdas can call them. Value-range checks (`fontSize`, `zoom`, `fontWeight`) stay inside their handlers.
- `Controller.java`: dropped the dead `command.commandExists = true;` write.
- `CommandCompletion.java` and its test are unchanged (still consume `COMMAND_NAMES`, still size 18).

## Tests

- Removed the one-directional sync test (`everyListedNameIsRecognizedByExecute`) — its job no longer exists — and rewrote the unknown-command test to assert the `doesn't exist` message.
- New `RegistryTests`: names derive from the registry with no duplicates; every `usage` starts with `:<name>`; missing required argument reports usage instead of crashing; blank/whitespace input is a no-op.
- All existing behavior tests (fontSize/fontWeight/italic/color/zoom/gridlines) kept as-is.

## Verification

Unit run green (Fedora/Wayland-safe):

```
./gradlew test --tests 'vimicalc.model.*' \
  --tests 'vimicalc.controller.KeyCommandParsingTest' \
  --tests 'vimicalc.controller.CommandCompletionTest'
```

UI tests (`AppUiTest`, etc.) were not run here — they need an X display (xvfb host); this change is confined to the model/controller command path they don't exercise.

Closes #63
Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)