### PR TITLE
Reapply #79 (issue #77 fixes) with merged-cell border rendering fix

### DIFF
--- a/src/main/java/vimicalc/controller/Controller.java
+++ b/src/main/java/vimicalc/controller/Controller.java
@@ -17,9 +17,10 @@ import static vimicalc.view.Defaults.*;
 
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.ResourceBundle;
 
 import static javafx.scene.input.KeyCode.ESCAPE;
@@ -80,10 +81,16 @@ public class Controller implements Initializable {
     private Label infoLabel;
     @FXML
     private Label exprLabel;
-    /** Stack of cell states recorded before each edit, used for undo. */
-    LinkedList<Cell> recordedCellStates;
-    /** Stack of cell states produced by undo, used for redo. */
-    LinkedList<Cell> undoneCellStates;
+    /**
+     * Undo history. Each entry is one edit step, holding the pre-edit states
+     * of every cell that step touched (a compound step for multi-cell
+     * operations like merge, unmerge, or VISUAL delete; a singleton list for
+     * plain cell edits). The first element is the cell the cursor returns to
+     * when the step is undone.
+     */
+    LinkedList<List<Cell>> recordedCellStates;
+    /** Stack of edit steps produced by undo, used for redo. */
+    LinkedList<List<Cell>> undoneCellStates;
     /** How many undo steps have been taken since the last edit. */
     int undoCounter;
     /** The clipboard for yank/paste operations. */
@@ -215,25 +222,13 @@ public class Controller implements Initializable {
             }
         }
 
-        System.out.println("     sC.x: "+cellSelector.getX()     +", yCoord: "+cellSelector.getY());
-        System.out.println("sC.xCoord: "+cellSelector.getXCoord()+", sC.yCoord: "+cellSelector.getYCoord());
-        System.out.println(" cam.absX: "+camera.getAbsX()        +", cam.absY: "+camera.getAbsY());
-        System.out.println("    Cells: "+sheet.getCells());
-        System.out.println("Selected cell: " + cellSelector.getSelectedCell());
-        System.out.println("========================================");
-
         if (currMode == Mode.NORMAL) {
             cellSelector.draw(gc);
             coordsInfo.setCoords(cellSelector.getXCoord(), cellSelector.getYCoord());
         }
         else if (currMode == Mode.VISUAL) {
-            System.out.println("Selected coords = {");
-            selectedCoords.forEach(c -> {
-                camera.picture.take(gc, sheet, selectedCoords, camera.getAbsX(), camera.getAbsY());
-                System.out.println('\t' + Arrays.toString(c));
-            });
+            camera.picture.take(gc, sheet, selectedCoords, camera.getAbsX(), camera.getAbsY());
             camera.ready();
-            System.out.println('}');
         }
         if (currMode != Mode.HELP) updateVisualState();
     }
@@ -318,7 +313,7 @@ public class Controller implements Initializable {
                         destinationCoord.reverse();
 
                         Cell c = sheet.findCell(destinationCoord.toString());
-                        recordedCellStates.add(c.copy());
+                        recordedCellStates.add(List.of(c.copy()));
                         Formula f = new Formula(
                             coordsInfo.getCoords() + ' ' + command.getTxt().substring(0, i),
                             c.xCoord(),
@@ -453,6 +448,21 @@ public class Controller implements Initializable {
             case DIGIT0, DIGIT1, DIGIT2, DIGIT3, DIGIT4, DIGIT5, DIGIT6, DIGIT7, DIGIT8, DIGIT9 ->
                 multiplierForVISUAL += event.getText();
             case D -> {
+                // Record the pre-images of every cell the delete will touch
+                // as one undo step. deleteCell follows merge redirection, so
+                // capture through findCell and de-duplicate: several selected
+                // coords inside one merge all blank the same merge-start.
+                List<Cell> deleteStep = new ArrayList<>();
+                HashSet<List<Integer>> seen = new HashSet<>();
+                for (int[] coord : selectedCoords) {
+                    Cell c = sheet.findCell(coord[0], coord[1]);
+                    if (!c.isEmpty() && seen.add(List.of(c.xCoord(), c.yCoord())))
+                        deleteStep.add(c.copy());
+                }
+                if (!deleteStep.isEmpty()) {
+                    recordedCellStates.add(deleteStep);
+                    if (undoCounter != 0) editorOps.removeUltCStates();
+                }
                 selectedCoords.forEach(coord -> sheet.deleteCell(coord[0], coord[1]));
                 camera.picture.take(gc, sheet, selectedCoords, camera.getAbsX(), camera.getAbsY());
                 camera.ready();
@@ -464,21 +474,31 @@ public class Controller implements Initializable {
                 camera.picture.take(gc, sheet, selectedCoords, camera.getAbsX(), camera.getAbsY());
                 camera.ready();
                 cellSelector.readCell(camera.picture.data());
-                System.out.println("Yanked coords: " + selectedCoords);
             }
             case M -> {
                 boolean mergedCsInside = false;
+                // Pre-images of every range dissolved below, recorded as one
+                // undo step. Each range is captured just before its unmerge:
+                // afterwards the cells' merge pointers are cleared, so the
+                // remaining coords of the same range are skipped naturally.
+                List<Cell> unmergeStep = new ArrayList<>();
 
                 for (int[] coord : selectedCoords) {
                     Cell c = sheet.findCell(coord[0], coord[1]);
                     if (c.getMergeDelimiter() != null) {
+                        int[] range = sheet.mergedRangeOf(c);
+                        if (range != null)
+                            unmergeStep.addAll(editorOps.captureRange(range[0], range[1], range[2], range[3]));
                         sheet.unmergeCells(c);
                         if (!mergedCsInside) mergedCsInside = true;
                     }
                 }
+                if (!unmergeStep.isEmpty()) {
+                    recordedCellStates.add(unmergeStep);
+                    if (undoCounter != 0) editorOps.removeUltCStates();
+                }
 
                 if (!mergedCsInside) {
-                    System.out.println("Merging cells...");
                     int maxXC = Integer.MIN_VALUE, minXC = Integer.MAX_VALUE,
                         maxYC = Integer.MIN_VALUE, minYC = Integer.MAX_VALUE;
                     for (int[] c : selectedCoords) {
@@ -488,26 +508,9 @@ public class Controller implements Initializable {
                         if (c[1] < minYC) minYC = c[1];
                     }
 
-                    Cell mergeStart = sheet.findCell(minXC, minYC);
-                    Cell mergeEnd = sheet.findCell(maxXC, maxYC);
-                    if (mergeStart.isEmpty()) sheet.addCell(mergeStart);
-                    if (mergeEnd.isEmpty()) sheet.addCell(mergeEnd);
-                    else mergeEnd = new Cell(mergeEnd.xCoord(), mergeEnd.yCoord());
-                    mergeStart.setMergeStart(true);
-                    mergeStart.mergeWith(mergeEnd);
-                    mergeEnd.mergeWith(mergeStart);
-
-                    for (int i = mergeStart.xCoord(); i <= mergeEnd.xCoord() ; i++) {
-                        for (int j = mergeStart.yCoord(); j <= mergeEnd.yCoord(); j++) {
-                            Cell c = sheet.findCell(i, j);
-                            if (c != mergeStart && c != mergeEnd) {
-                                if (!c.isEmpty())
-                                    c = new Cell(c.xCoord(), c.yCoord());
-                                sheet.addCell(c);
-                                c.mergeWith(mergeStart);
-                            }
-                        }
-                    }
+                    recordedCellStates.add(editorOps.captureRange(minXC, minYC, maxXC, maxYC));
+                    if (undoCounter != 0) editorOps.removeUltCStates();
+                    sheet.mergeCells(minXC, minYC, maxXC, maxYC);
                 }
 
                 selectedCoords = new ArrayList<>();
@@ -560,11 +563,6 @@ public class Controller implements Initializable {
                     maxYC = originalYC;
                     minYC = maxYC;
                 }
-                System.out.println("maxXC: " + maxXC);
-                System.out.println("minXC: " + minXC);
-                System.out.println("maxYC: " + maxYC);
-                System.out.println("minYC: " + minYC);
-
                 if (maxXC > camera.picture.metadata().getMaxXC() ||
                     maxYC > camera.picture.metadata().getMaxYC()) {
                     if (maxXC > camera.picture.metadata().getMaxXC()) camera.picture.metadata().setMaxXC(maxXC);
@@ -581,11 +579,6 @@ public class Controller implements Initializable {
                 }
                 int currXC = cellSelector.getXCoord();
                 int currYC = cellSelector.getYCoord();
-                System.out.println("currXC: " + currXC);
-                System.out.println("currYC: " + currYC);
-
-                System.out.println("originalXC = " + originalXC);
-                System.out.println("originalYC = " + originalYC);
 
                 if (currXC >= originalXC && currYC >= originalYC) {
                     if (currXC > prevXC) {
@@ -671,14 +664,10 @@ public class Controller implements Initializable {
     }
     /** Adds a full column or row of coordinates to the visual selection. */
     private void addSCs(boolean isAddingCol, int currC, int minC, int maxC) {
-        if (isAddingCol) for (int i = minC; i <= maxC; i++) {
+        if (isAddingCol) for (int i = minC; i <= maxC; i++)
             selectedCoords.add(new int[]{currC, i});
-            System.out.println(currC + ", " + i);
-        }
-        else for (int i = minC; i <= maxC; i++) {
+        else for (int i = minC; i <= maxC; i++)
             selectedCoords.add(new int[]{i, currC});
-            System.out.println(currC + ", " + i);
-        }
     }
     /** Removes all selected coordinates in the given column or row ({@code -1} to skip). */
     private void purgeSCs(int col, int row) {
@@ -742,7 +731,7 @@ public class Controller implements Initializable {
                         case L -> moveRight();
                         default -> {}
                     }
-                    recordedCellStates.add(cellSelector.getSelectedCell().copy());
+                    recordedCellStates.add(List.of(cellSelector.getSelectedCell().copy()));
                     setSCTxtForTextInput();
                     cellSelector.draw(gc);
                 } else {
@@ -824,7 +813,7 @@ public class Controller implements Initializable {
                             case L -> moveRight();
                             default -> {}
                         }
-                        recordedCellStates.add(cellSelector.getSelectedCell().copy());
+                        recordedCellStates.add(List.of(cellSelector.getSelectedCell().copy()));
                         currMode = Mode.FORMULA;
                         if (cellSelector.getSelectedCell().formula() == null)
                             cellSelector.getSelectedCell().setFormula(

--- a/src/main/java/vimicalc/controller/EditorOperations.java
+++ b/src/main/java/vimicalc/controller/EditorOperations.java
@@ -1,7 +1,12 @@
 package vimicalc.controller;
 
+import org.jetbrains.annotations.NotNull;
 import vimicalc.model.*;
 import vimicalc.view.Positions;
+
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
 
 import static vimicalc.view.Defaults.*;
 
@@ -246,66 +251,108 @@ public class EditorOperations {
      * partially-undone state.
      */
     public void removeUltCStates() {
-        Cell last = ctrl.recordedCellStates.getLast().copy();
+        List<Cell> last = copyStep(ctrl.recordedCellStates.getLast());
         ctrl.recordedCellStates.removeLast();
         while (ctrl.undoCounter != 0) {
             ctrl.recordedCellStates.removeLast();
             ctrl.undoCounter--;
         }
         ctrl.recordedCellStates.add(last);
-        ctrl.undoneCellStates = new java.util.LinkedList<>();
+        ctrl.undoneCellStates = new LinkedList<>();
     }
 
-    /** Reverts the last cell edit by swapping the current state with the recorded previous state. */
+    /**
+     * Captures pre-images of every cell in the given rectangle (exact
+     * per-coordinate states, no merge redirection), merge-start corner
+     * first, for recording as one undo step.
+     *
+     * @param x1 the top-left column (one-based)
+     * @param y1 the top-left row
+     * @param x2 the bottom-right column
+     * @param y2 the bottom-right row
+     * @return the captured cell states, ordered row-major from ({@code x1},{@code y1})
+     */
+    public List<Cell> captureRange(int x1, int y1, int x2, int y2) {
+        List<Cell> step = new ArrayList<>();
+        for (int i = x1; i <= x2; i++)
+            for (int j = y1; j <= y2; j++)
+                step.add(ctrl.sheet.simplyFindCell(i, j).copy());
+        return step;
+    }
+
+    /** Deep-copies an undo step (each cell state is copied). */
+    private List<Cell> copyStep(@NotNull List<Cell> step) {
+        List<Cell> copy = new ArrayList<>();
+        for (Cell c : step) copy.add(c.copy());
+        return copy;
+    }
+
+    /**
+     * Reverts the last edit step: every touched cell swaps its current state
+     * with the recorded pre-edit state.
+     */
     public void undo() {
         int listIndex = ctrl.recordedCellStates.size() - 1 - ctrl.undoCounter;
         ctrl.undoCounter++;
 
-        Cell substitute = ctrl.recordedCellStates.get(listIndex).copy();
-        goTo(substitute.xCoord(), substitute.yCoord());
-        ctrl.recordedCellStates.set(listIndex, ctrl.sheet.findCell(substitute.xCoord(), substitute.yCoord()).copy());
-        ctrl.undoneCellStates.add(substitute);
-        ctrl.sheet.deleteCell(substitute.xCoord(), substitute.yCoord());
+        List<Cell> step = copyStep(ctrl.recordedCellStates.get(listIndex));
+        goTo(step.get(0).xCoord(), step.get(0).yCoord());
+        List<Cell> currentStates = new ArrayList<>();
+        for (Cell state : step)
+            currentStates.add(ctrl.sheet.simplyFindCell(state.xCoord(), state.yCoord()).copy());
+        ctrl.recordedCellStates.set(listIndex, currentStates);
+        ctrl.undoneCellStates.add(step);
 
-        if (substitute.formula() != null) {
-            Formula f = substitute.formula();
-            try {
-                ctrl.cellSelector.getSelectedCell().setFormulaResult(f.interpret(ctrl.sheet), f);
-            } catch (Exception e) {
-                System.out.println(e.getMessage());
-                System.out.println("Something went very wrong.");
-            }
-        } else ctrl.cellSelector.setSelectedCell(substitute);
-
-        cellContentToIBar();
-        ctrl.sheet.addCell(ctrl.cellSelector.getSelectedCell());
-        ctrl.sheet.getCells().forEach(Cell::isEmpty);
+        applyStep(step);
     }
 
-    /** Re-applies a previously undone cell edit. */
+    /** Re-applies a previously undone edit step. */
     public void redo() {
         int listIndex = ctrl.recordedCellStates.size() - ctrl.undoCounter;
         ctrl.undoCounter--;
 
-        Cell substitute = ctrl.recordedCellStates.get(listIndex).copy();
-        goTo(substitute.xCoord(), substitute.yCoord());
-        ctrl.recordedCellStates.set(listIndex, ctrl.undoneCellStates.getLast().copy());
+        List<Cell> step = copyStep(ctrl.recordedCellStates.get(listIndex));
+        goTo(step.get(0).xCoord(), step.get(0).yCoord());
+        ctrl.recordedCellStates.set(listIndex, copyStep(ctrl.undoneCellStates.getLast()));
         ctrl.undoneCellStates.removeLast();
-        ctrl.sheet.deleteCell(substitute.xCoord(), substitute.yCoord());
 
-        if (substitute.formula() != null) {
-            Formula f = substitute.formula();
-            try {
-                ctrl.cellSelector.getSelectedCell().setFormulaResult(f.interpret(ctrl.sheet), f);
-            } catch (Exception e) {
-                System.out.println(e.getMessage());
-                System.out.println("Something went very wrong.");
+        applyStep(step);
+    }
+
+    /**
+     * Writes the given cell states into the sheet: each coordinate is cleared
+     * and, unless the state is empty, the snapshot is re-added (formulas are
+     * re-interpreted). Restored merge pointers reference snapshot objects, so
+     * every merge range in the step is re-linked through the live cell map
+     * afterwards (see {@link Sheet#relinkMergedRange}).
+     */
+    private void applyStep(@NotNull List<Cell> step) {
+        for (Cell state : step) {
+            ctrl.sheet.simplyDeleteCell(state.xCoord(), state.yCoord());
+            if (state.isEmpty()) continue;
+            Cell restored = state.copy();
+            if (restored.formula() != null) {
+                Formula f = restored.formula();
+                try {
+                    restored.setFormulaResult(f.interpret(ctrl.sheet), f);
+                } catch (Exception e) {
+                    ctrl.infoBar.setInfobarTxt(e.getMessage());
+                }
             }
-        } else ctrl.cellSelector.setSelectedCell(substitute);
+            ctrl.sheet.addCell(restored);
+        }
+        for (Cell state : step)
+            if (state.isMergeStart() && state.getMergeDelimiter() != null)
+                ctrl.sheet.relinkMergedRange(
+                    state.xCoord(), state.yCoord(),
+                    state.getMergeDelimiter().xCoord(), state.getMergeDelimiter().yCoord()
+                );
+        ctrl.sheet.purgeEmptyCells();
 
+        ctrl.cellSelector.setSelectedCell(
+            ctrl.sheet.findCell(step.get(0).xCoord(), step.get(0).yCoord()).copy()
+        );
         cellContentToIBar();
-        ctrl.sheet.addCell(ctrl.cellSelector.getSelectedCell());
-        ctrl.sheet.getCells().forEach(Cell::isEmpty);
     }
 
     /**
@@ -389,7 +436,7 @@ public class EditorOperations {
                 ctrl.cellSelector.getYCoord()
             );
             try {
-                ctrl.recordedCellStates.add(ctrl.cellSelector.getSelectedCell().copy());
+                ctrl.recordedCellStates.add(List.of(ctrl.cellSelector.getSelectedCell().copy()));
                 ctrl.sheet.deleteCell(ctrl.cellSelector.getXCoord(), ctrl.cellSelector.getYCoord());
                 ctrl.cellSelector.getSelectedCell().setFormulaResult(f.interpret(ctrl.sheet), f);
             } catch (Exception e) {
@@ -397,7 +444,7 @@ public class EditorOperations {
                 return;
             }
         } else {
-            ctrl.recordedCellStates.add(ctrl.cellSelector.getSelectedCell().copy());
+            ctrl.recordedCellStates.add(List.of(ctrl.cellSelector.getSelectedCell().copy()));
             ctrl.sheet.deleteCell(ctrl.cellSelector.getXCoord(), ctrl.cellSelector.getYCoord());
             ctrl.cellSelector.setSelectedCell(ctrl.clipboard.get(index).copy());
         }

--- a/src/main/java/vimicalc/controller/KeyCommand.java
+++ b/src/main/java/vimicalc/controller/KeyCommand.java
@@ -5,6 +5,7 @@ import javafx.animation.Timeline;
 import javafx.scene.input.KeyEvent;
 import javafx.util.Duration;
 import org.jetbrains.annotations.NotNull;
+import vimicalc.model.Cell;
 import vimicalc.model.Command;
 import vimicalc.model.CommandResult;
 import vimicalc.model.Formula;
@@ -340,7 +341,7 @@ public class KeyCommand {
         for (int i = 0; i < first.multiplier; i++) {
             switch (fstFunc) {
                 case '=' -> {
-                    ctrl.recordedCellStates.add(ctrl.cellSelector.getSelectedCell().copy());
+                    ctrl.recordedCellStates.add(List.of(ctrl.cellSelector.getSelectedCell().copy()));
                     ctrl.currMode = Mode.FORMULA;
                     ctrl.cellSelector.readCell(ctrl.camera.picture.data());
                     if (ctrl.cellSelector.getSelectedCell().formula() == null)
@@ -453,7 +454,7 @@ public class KeyCommand {
                                 ctrl.infoBar.setInfobarTxt("CAN'T DELETE RIGHT NOW");
                                 ctrl.sheet.deleteDependency(ctrl.cellSelector.getXCoord(), ctrl.cellSelector.getYCoord());
                             } else {
-                                ctrl.recordedCellStates.add(ctrl.cellSelector.getSelectedCell().copy());
+                                ctrl.recordedCellStates.add(List.of(ctrl.cellSelector.getSelectedCell().copy()));
                                 ctrl.sheet.deleteCell(ctrl.cellSelector.getXCoord(), ctrl.cellSelector.getYCoord());
                                 ctrl.camera.picture.take(ctrl.gc, ctrl.sheet, ctrl.selectedCoords, ctrl.camera.getAbsX(), ctrl.camera.getAbsY());
                                 ctrl.camera.ready();
@@ -467,7 +468,13 @@ public class KeyCommand {
                     }
                 }
                 case 'm' -> {
-                    ctrl.sheet.unmergeCells(ctrl.sheet.findCell(ctrl.coordsInfo.getCoords()));
+                    Cell unmergeTarget = ctrl.sheet.findCell(ctrl.coordsInfo.getCoords());
+                    int[] range = ctrl.sheet.mergedRangeOf(unmergeTarget);
+                    if (range != null) {
+                        ctrl.recordedCellStates.add(ops.captureRange(range[0], range[1], range[2], range[3]));
+                        if (ctrl.undoCounter != 0) ops.removeUltCStates();
+                    }
+                    ctrl.sheet.unmergeCells(unmergeTarget);
                     ctrl.camera.picture.take(ctrl.gc, ctrl.sheet, ctrl.selectedCoords, ctrl.camera.getAbsX(), ctrl.camera.getAbsY());
                     ctrl.camera.ready();
                     ctrl.cellSelector.readCell(ctrl.camera.picture.data());
@@ -482,8 +489,6 @@ public class KeyCommand {
                         ctrl.camera.ready();
                         ctrl.cellSelector.readCell(ctrl.camera.picture.data());
                     }
-                    System.out.println("Recorded cell states: ");
-                    ctrl.recordedCellStates.forEach(c -> System.out.println("xC = " + c.xCoord() + ", yC = " + c.yCoord()));
                     evaluationFinished = true;
                 }
                 case 'r' -> {
@@ -495,8 +500,6 @@ public class KeyCommand {
                         ctrl.camera.ready();
                         ctrl.cellSelector.readCell(ctrl.camera.picture.data());
                     }
-                    System.out.println("Recorded cell states: ");
-                    ctrl.recordedCellStates.forEach(c -> System.out.println("xC = " + c.xCoord() + ", yC = " + c.yCoord()));
                     evaluationFinished = true;
                 }
                 case 'y' -> {
@@ -545,7 +548,7 @@ public class KeyCommand {
                     }
                 }
                 case 'a', 'i' -> {
-                    ctrl.recordedCellStates.add(ctrl.cellSelector.getSelectedCell().copy());
+                    ctrl.recordedCellStates.add(List.of(ctrl.cellSelector.getSelectedCell().copy()));
                     ops.setSCTxtForTextInput();
                     ctrl.currMode = Mode.INSERT;
                     ctrl.cellSelector.draw(ctrl.gc);

--- a/src/main/java/vimicalc/model/Sheet.java
+++ b/src/main/java/vimicalc/model/Sheet.java
@@ -123,6 +123,20 @@ public class Sheet {
     }
 
     /**
+     * Removes the exact cell at the given coordinates — no merge redirection
+     * and no merge-structure preservation — along with its dependency. Used
+     * when restoring recorded cell states (undo/redo), where the snapshot
+     * fully defines the target state including any merge links.
+     *
+     * @param xCoord the one-based column index
+     * @param yCoord the row number
+     */
+    public void simplyDeleteCell(int xCoord, int yCoord) {
+        cells.remove(cellKey(xCoord, yCoord));
+        deleteDependency(xCoord, yCoord);
+    }
+
+    /**
      * Removes the dependency at the given coordinates. First clears the
      * dependency's {@code dependeds} list (upstream references), then checks
      * whether it still has dependents (downstream cells that reference it).
@@ -184,38 +198,121 @@ public class Sheet {
     }
 
     /**
+     * Resolves the merged range that the given cell belongs to.
+     *
+     * <p>Merge pointers can reference an object that {@code addCell} has since
+     * replaced in the cell map (e.g. after editing the merged cell's text), so
+     * the merge-start is resolved through the map — otherwise an orphaned copy
+     * would be consulted (issue #29).</p>
+     *
+     * @param c any cell in the merge group
+     * @return {@code {startX, startY, endX, endY}}, or {@code null} if the
+     *         cell is not part of a merged range
+     */
+    public int[] mergedRangeOf(@NotNull Cell c) {
+        Cell mergeStart = c.isMergeStart() ? c : c.getMergeDelimiter();
+        if (mergeStart == null) return null;
+        Cell mapped = simplyFindCell(mergeStart.xCoord(), mergeStart.yCoord());
+        if (mapped.isMergeStart()) mergeStart = mapped;
+        if (mergeStart.getMergeDelimiter() == null) return null;
+        return new int[]{
+            mergeStart.xCoord(), mergeStart.yCoord(),
+            mergeStart.getMergeDelimiter().xCoord(), mergeStart.getMergeDelimiter().yCoord()
+        };
+    }
+
+    /**
      * Unmerges all cells in the merge group that the given cell belongs to.
      * Works whether the cell is the merge-start or any cell within the range.
      *
      * @param c any cell in the merge group
      */
     public void unmergeCells(@NotNull Cell c) {
-        Cell mergeStart = c.isMergeStart() ? c : c.getMergeDelimiter();
-        if (mergeStart == null) return;
-        // Merge pointers can reference an object that addCell has since
-        // replaced in the cell map (e.g. after editing the merged cell's
-        // text), so resolve the merge-start through the map before mutating
-        // it — otherwise only the orphaned copy gets unmerged (issue #29).
-        Cell mapped = simplyFindCell(mergeStart.xCoord(), mergeStart.yCoord());
-        if (mapped.isMergeStart()) mergeStart = mapped;
-        if (mergeStart.getMergeDelimiter() != null)
-            unmergeCells(mergeStart, mergeStart.getMergeDelimiter());
-    }
-    private void unmergeCells(@NotNull Cell mergeStart, @NotNull Cell mergeEnd) {
-        System.out.println("Unmerging cells...");
-        Cell c;
-        for (int i = mergeStart.xCoord(); i <= mergeEnd.xCoord(); ++i) {
-            for (int j = mergeStart.yCoord(); j <= mergeEnd.yCoord(); ++j) {
-                c = simplyFindCell(i, j);
-                System.out.println("i = " + i + ", j = " + j);
-                System.out.println("Unmerging: " + c);
-                if (!c.isMergeStart())
-                    c.mergeWith(null);
-                simplyAddCell(c);
+        int[] range = mergedRangeOf(c);
+        if (range == null) return;
+        Cell mergeStart = simplyFindCell(range[0], range[1]);
+        for (int i = range[0]; i <= range[2]; ++i) {
+            for (int j = range[1]; j <= range[3]; ++j) {
+                Cell in = simplyFindCell(i, j);
+                if (!in.isMergeStart())
+                    in.mergeWith(null);
+                simplyAddCell(in);
             }
         }
         mergeStart.mergeWith(null);
         mergeStart.setMergeStart(false);
+        purgeEmptyCells();
+    }
+
+    /**
+     * Merges the rectangular range with top-left corner ({@code x1},{@code y1})
+     * and bottom-right corner ({@code x2},{@code y2}) into a single block. The
+     * top-left cell keeps its content; every other cell in the range —
+     * including a non-empty bottom-right corner — is replaced by an empty cell
+     * linked to the merge-start, discarding its content (as in other
+     * spreadsheets, only the top-left value survives a merge).
+     *
+     * @param x1 the merge-start column (one-based)
+     * @param y1 the merge-start row
+     * @param x2 the merge-end column
+     * @param y2 the merge-end row
+     */
+    public void mergeCells(int x1, int y1, int x2, int y2) {
+        Cell mergeStart = findCell(x1, y1);
+        Cell mergeEnd = findCell(x2, y2);
+        if (mergeStart.isEmpty()) addCell(mergeStart);
+        if (mergeEnd.isEmpty()) addCell(mergeEnd);
+        else mergeEnd = new Cell(x2, y2);
+        mergeStart.setMergeStart(true);
+        mergeStart.mergeWith(mergeEnd);
+        mergeEnd.mergeWith(mergeStart);
+
+        for (int i = x1; i <= x2; i++) {
+            for (int j = y1; j <= y2; j++) {
+                Cell c = findCell(i, j);
+                if (c != mergeStart && c != mergeEnd) {
+                    if (!c.isEmpty())
+                        c = new Cell(i, j);
+                    addCell(c);
+                    c.mergeWith(mergeStart);
+                }
+            }
+        }
+    }
+
+    /**
+     * Re-links the merge pointers of the range with top-left corner
+     * ({@code x1},{@code y1}) and bottom-right corner ({@code x2},{@code y2})
+     * so they reference the objects currently in the cell map. Restoring
+     * snapshot copies (undo/redo) leaves merge pointers aimed at stale
+     * objects (issue #29); unlike {@link #mergeCells}, this never discards
+     * cell contents.
+     *
+     * @param x1 the merge-start column (one-based)
+     * @param y1 the merge-start row
+     * @param x2 the merge-end column
+     * @param y2 the merge-end row
+     */
+    public void relinkMergedRange(int x1, int y1, int x2, int y2) {
+        Cell mergeStart = simplyFindCell(x1, y1);
+        Cell mergeEnd = new Cell(x2, y2);
+        mergeStart.setMergeStart(true);
+        mergeStart.mergeWith(mergeEnd);
+        mergeEnd.mergeWith(mergeStart);
+        simplyAddCell(mergeStart);
+        for (int i = x1; i <= x2; i++) {
+            for (int j = y1; j <= y2; j++) {
+                if (i == x1 && j == y1) continue;
+                Cell in = simplyFindCell(i, j);
+                in.setMergeStart(false);
+                in.mergeWith(mergeStart);
+                simplyAddCell(in);
+            }
+        }
+    }
+
+    /** Removes every cell that has neither content nor a merge reference. */
+    public void purgeEmptyCells() {
         cells.values().removeIf(Cell::isEmpty);
     }
 

--- a/src/main/java/vimicalc/view/Picture.java
+++ b/src/main/java/vimicalc/view/Picture.java
@@ -211,10 +211,12 @@ public class Picture extends simpleRect {
             } else {
                 // An unformatted merge block gets no covering fill from
                 // renderCell, so fill it here — otherwise the gridlines
-                // drawn under it keep splitting the block into cells.
+                // drawn under it keep splitting the block into cells. The
+                // 1px top/left inset spares the block's own border lines,
+                // whose strokes occupy the pixel at the boundary coordinate.
                 if (c.isMergeStart()) {
                     gc.setFill(DEFAULT_CELL_C);
-                    gc.fillRect(cellX, cellY, cellWidth, cellHeight);
+                    gc.fillRect(cellX + 1, cellY + 1, cellWidth - 1, cellHeight - 1);
                     gc.setFill(Color.BLACK);
                 }
                 gc.fillText(

--- a/src/main/java/vimicalc/view/Picture.java
+++ b/src/main/java/vimicalc/view/Picture.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static vimicalc.view.Defaults.DEFAULT_CELL_C;
 import static vimicalc.view.Defaults.DEFAULT_FONT_SIZE;
 import static vimicalc.view.Defaults.GRIDLINE_C;
 import static vimicalc.view.Defaults.GUTTER_W;
@@ -202,22 +203,24 @@ public class Picture extends simpleRect {
                 cellWidth = metadata.getCellAbsXs()[c.xCoord()+1] - metadata.getCellAbsXs()[c.xCoord()];
             }
 
-            try {
-                System.out.println(cellsFormatting.get(List.of(c.xCoord(), c.yCoord())));
-                cellsFormatting.get(List.of(c.xCoord(), c.yCoord())).renderCell(
-                    gc,
-                    metadata.getCellAbsXs()[c.xCoord()] - absX + GUTTER_W,
-                    metadata.getCellAbsYs()[c.yCoord()] - absY + HEADER_H,
-                    cellWidth,
-                    cellHeight,
-                    c.txt(),
-                    metadata.getZoom()
-                );
-            } catch (Exception ignored) {
+            int cellX = metadata.getCellAbsXs()[c.xCoord()] - absX + GUTTER_W;
+            int cellY = metadata.getCellAbsYs()[c.yCoord()] - absY + HEADER_H;
+            Formatting formatting = cellsFormatting.get(List.of(c.xCoord(), c.yCoord()));
+            if (formatting != null) {
+                formatting.renderCell(gc, cellX, cellY, cellWidth, cellHeight, c.txt(), metadata.getZoom());
+            } else {
+                // An unformatted merge block gets no covering fill from
+                // renderCell, so fill it here — otherwise the gridlines
+                // drawn under it keep splitting the block into cells.
+                if (c.isMergeStart()) {
+                    gc.setFill(DEFAULT_CELL_C);
+                    gc.fillRect(cellX, cellY, cellWidth, cellHeight);
+                    gc.setFill(Color.BLACK);
+                }
                 gc.fillText(
                     c.txt(),
-                   metadata.getCellAbsXs()[c.xCoord()] - absX + GUTTER_W + (float) cellWidth / 2,
-                   metadata.getCellAbsYs()[c.yCoord()] - absY + HEADER_H + (float) cellHeight / 2,
+                    cellX + (float) cellWidth / 2,
+                    cellY + (float) cellHeight / 2,
                     cellWidth
                 );
             }

--- a/src/test/java/vimicalc/controller/KeyCommandManualTests.md
+++ b/src/test/java/vimicalc/controller/KeyCommandManualTests.md
@@ -135,6 +135,14 @@ Legend:
 3. Press `u` once — all three values return together
 4. Press `r` — the whole block clears again
 
+### 5.8 Merged block keeps all four border gridlines (issue #77)
+1. Go to B5 (`g` `B` `5` `l`, then `h` back), press `v`, extend to E10, press `m`
+2. Move the cursor off the block — **all four** border gridlines of the
+   merged block are visible (top and left included), while the gridlines
+   *inside* the block are gone
+3. Scroll around (e.g. `20j` then `20k`) and re-check — the borders persist
+   across repaints
+
 ---
 
 ## 6. Go-to (g{coords})

--- a/src/test/java/vimicalc/controller/KeyCommandManualTests.md
+++ b/src/test/java/vimicalc/controller/KeyCommandManualTests.md
@@ -116,6 +116,25 @@ Legend:
 ### 5.4 Redo at limit
 1. Fresh launch, press `r` — info bar shows "Already at latest change."
 
+### 5.5 Undo a merge (compound step, issue #77)
+1. Enter "top" in A1 and "mid" in B1
+2. At A1, press `v` `l` `j` `m` — A1:B2 merge into one block, "mid" disappears
+3. Press `u` — the merge dissolves and **both** "top" and "mid" are back
+4. Press `r` — the block is merged again, "mid" is blanked again
+
+### 5.6 Undo an unmerge
+1. Merge A1:B2 as in 5.5
+2. Press `m` — the block unmerges
+3. Press `u` — the merge is restored (moving into any cell of the range
+   pulls the cursor to A1)
+4. Press `u` again — steps back over the original merge as well
+
+### 5.7 Undo a VISUAL-mode delete (one step)
+1. Enter "a" in A1, "b" in B1, "c" in A2
+2. At A1, press `v` `l` `j` `d`, then Escape — all cells in the block clear
+3. Press `u` once — all three values return together
+4. Press `r` — the whole block clears again
+
 ---
 
 ## 6. Go-to (g{coords})

--- a/src/test/java/vimicalc/controller/UndoMergeUiTest.java
+++ b/src/test/java/vimicalc/controller/UndoMergeUiTest.java
@@ -1,0 +1,234 @@
+package vimicalc.controller;
+
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Parent;
+import javafx.scene.Scene;
+import javafx.scene.canvas.Canvas;
+import javafx.scene.image.PixelReader;
+import javafx.scene.image.WritableImage;
+import javafx.scene.input.KeyCode;
+import javafx.scene.paint.Color;
+import javafx.stage.Stage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testfx.api.FxRobot;
+import org.testfx.framework.junit5.ApplicationExtension;
+import org.testfx.framework.junit5.Start;
+import vimicalc.Main;
+import vimicalc.model.Cell;
+import vimicalc.view.Formatting;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static vimicalc.view.Defaults.GRIDLINE_C;
+import static vimicalc.view.Defaults.GUTTER_W;
+import static vimicalc.view.Defaults.HEADER_H;
+
+/**
+ * Regression tests for issue #77: compound undo/redo of merge, unmerge, and
+ * VISUAL-mode delete; merged cells covering their interior gridlines; and the
+ * VISUAL-mode repaint explosion on large formatted selections.
+ */
+@ExtendWith(ApplicationExtension.class)
+class UndoMergeUiTest {
+
+    private Controller controller;
+    private Scene scene;
+
+    @Start
+    void start(Stage stage) throws Exception {
+        FXMLLoader loader = new FXMLLoader(Main.class.getResource("GUI.fxml"));
+        Parent root = loader.load();
+        controller = loader.getController();
+        scene = new Scene(root, 900, 600);
+        scene.setOnKeyPressed(controller::onKeyPressed);
+        stage.setScene(scene);
+        // TestFX reuses one primary stage across test classes; with the
+        // resizable layout (#46) content follows the stage, so pin the size.
+        stage.setWidth(900);
+        stage.setHeight(600);
+        stage.show();
+    }
+
+    @Test
+    void mergeIsUndoableAndRedoable(FxRobot robot) {
+        // B2 = "top", C2 = "mid", cursor back on B2
+        robot.type(KeyCode.I);
+        typeText(robot, "top");
+        robot.type(KeyCode.ESCAPE, KeyCode.L, KeyCode.I);
+        typeText(robot, "mid");
+        robot.type(KeyCode.ESCAPE, KeyCode.H);
+
+        // Merge B2:C3 — the merge blanks every non-top-left cell
+        robot.type(KeyCode.V, KeyCode.L, KeyCode.J, KeyCode.M);
+        assertTrue(controller.sheet.simplyFindCell(2, 2).isMergeStart());
+        assertNull(controller.sheet.simplyFindCell(3, 2).txt(),
+            "merging must blank the non-top-left contents");
+
+        robot.type(KeyCode.U);
+        assertFalse(controller.sheet.simplyFindCell(2, 2).isMergeStart(),
+            "undo must dissolve the merge");
+        assertNull(controller.sheet.simplyFindCell(3, 2).getMergeDelimiter(),
+            "undo must clear interior merge pointers");
+        assertEquals("top", controller.sheet.simplyFindCell(2, 2).txt());
+        assertEquals("mid", controller.sheet.simplyFindCell(3, 2).txt(),
+            "undo must bring back the contents the merge destroyed");
+
+        robot.type(KeyCode.R);
+        Cell start = controller.sheet.simplyFindCell(2, 2);
+        assertTrue(start.isMergeStart(), "redo must re-apply the merge");
+        assertEquals("top", start.txt());
+        assertNull(controller.sheet.simplyFindCell(3, 2).txt());
+        assertSame(start, controller.sheet.simplyFindCell(3, 2).getMergeDelimiter(),
+            "re-applied interior pointers must reference the live merge start");
+
+        robot.type(KeyCode.U);
+        assertEquals("mid", controller.sheet.simplyFindCell(3, 2).txt(),
+            "a second undo must restore the contents again");
+    }
+
+    @Test
+    void normalModeUnmergeIsUndoable(FxRobot robot) {
+        robot.type(KeyCode.V, KeyCode.L, KeyCode.J, KeyCode.M); // merge B2:C3
+        robot.type(KeyCode.M);                                  // NORMAL-mode unmerge
+        assertFalse(controller.sheet.simplyFindCell(2, 2).isMergeStart());
+
+        robot.type(KeyCode.U);
+        Cell start = controller.sheet.simplyFindCell(2, 2);
+        assertTrue(start.isMergeStart(), "undo must restore the merge");
+        assertNotNull(start.getMergeDelimiter());
+        assertEquals(3, start.getMergeDelimiter().xCoord());
+        assertEquals(3, start.getMergeDelimiter().yCoord());
+        assertSame(start, controller.sheet.simplyFindCell(3, 2).getMergeDelimiter(),
+            "restored interior pointers must reference the live merge start");
+        assertSame(start, controller.sheet.findCell(3, 3),
+            "merge redirection must work on the restored range");
+
+        // One more undo steps back over the original merge as well
+        robot.type(KeyCode.U);
+        assertFalse(controller.sheet.simplyFindCell(2, 2).isMergeStart());
+    }
+
+    @Test
+    void visualModeUnmergeIsUndoable(FxRobot robot) {
+        robot.type(KeyCode.V, KeyCode.L, KeyCode.J, KeyCode.M); // merge B2:C3
+        robot.type(KeyCode.V, KeyCode.M);                       // VISUAL m on a merged cell unmerges
+        assertFalse(controller.sheet.simplyFindCell(2, 2).isMergeStart());
+
+        robot.type(KeyCode.U);
+        assertTrue(controller.sheet.simplyFindCell(2, 2).isMergeStart(),
+            "undo must restore the merge dissolved from VISUAL mode");
+    }
+
+    @Test
+    void visualDeleteIsUndoableAsOneStep(FxRobot robot) {
+        // B2 = "aa", C2 = "bb", B3 = "cc", cursor back on B2
+        robot.type(KeyCode.I);
+        typeText(robot, "aa");
+        robot.type(KeyCode.ESCAPE, KeyCode.L, KeyCode.I);
+        typeText(robot, "bb");
+        robot.type(KeyCode.ESCAPE, KeyCode.H, KeyCode.J, KeyCode.I);
+        typeText(robot, "cc");
+        robot.type(KeyCode.ESCAPE, KeyCode.K);
+
+        robot.type(KeyCode.V, KeyCode.L, KeyCode.J, KeyCode.D);
+        robot.type(KeyCode.ESCAPE);
+        assertNull(controller.sheet.simplyFindCell(2, 2).txt());
+        assertNull(controller.sheet.simplyFindCell(3, 2).txt());
+        assertNull(controller.sheet.simplyFindCell(2, 3).txt());
+
+        robot.type(KeyCode.U);
+        assertEquals("aa", controller.sheet.simplyFindCell(2, 2).txt(),
+            "one undo must restore every cell the VISUAL delete removed");
+        assertEquals("bb", controller.sheet.simplyFindCell(3, 2).txt());
+        assertEquals("cc", controller.sheet.simplyFindCell(2, 3).txt());
+
+        robot.type(KeyCode.R);
+        assertNull(controller.sheet.simplyFindCell(2, 2).txt(),
+            "redo must re-apply the whole delete step");
+        assertNull(controller.sheet.simplyFindCell(3, 2).txt());
+        assertNull(controller.sheet.simplyFindCell(2, 3).txt());
+    }
+
+    @Test
+    void largeFormattedVisualSelectionDoesNotThrow(FxRobot robot) {
+        // Issue #77 bug 3: with per-cell formatting present, extending a big
+        // VISUAL selection used to trigger one full repaint per selected
+        // coordinate per keystroke, flooding the Canvas command buffer until
+        // the heap died (OutOfMemoryError below Formatting.renderCell).
+        List<Throwable> fxErrors = new CopyOnWriteArrayList<>();
+        robot.interact(() -> {
+            Thread.currentThread().setUncaughtExceptionHandler((t, e) -> fxErrors.add(e));
+            Formatting red = new Formatting();
+            red.setCellColor(Color.RED);
+            for (int i = 2; i <= 21; i++)
+                for (int j = 2; j <= 21; j++)
+                    controller.sheet.addFormatting(i, j, red);
+        });
+
+        robot.type(KeyCode.V);
+        for (int i = 0; i < 19; i++) robot.type(KeyCode.L);
+        for (int i = 0; i < 19; i++) robot.type(KeyCode.J);
+
+        assertEquals(400, controller.selectedCoords.size(),
+            "the whole 20x20 formatted block should be selected");
+        assertTrue(fxErrors.isEmpty(),
+            "selecting a large formatted block must not raise FX-thread errors: " + fxErrors);
+    }
+
+    @Test
+    void unformattedMergeCoversItsInteriorGridlines(FxRobot robot) {
+        // Merge B2:C3 with no formatting anywhere; gridlines are on by default
+        robot.type(KeyCode.V, KeyCode.L, KeyCode.J, KeyCode.M);
+        // Move the cursor off the merge so its opaque highlight doesn't
+        // cover the pixels under test
+        robot.type(KeyCode.L, KeyCode.L, KeyCode.J, KeyCode.J);
+
+        AtomicReference<WritableImage> shot = new AtomicReference<>();
+        robot.interact(() -> {
+            Canvas canvas = (Canvas) scene.lookup("#canvas");
+            shot.set(canvas.snapshot(null, null));
+        });
+        PixelReader pixels = shot.get().getPixelReader();
+
+        int[] xs = controller.camera.picture.metadata().getCellAbsXs();
+        int[] ys = controller.camera.picture.metadata().getCellAbsYs();
+        // Canvas-local x of the column 2|3 boundary — inside the merge from
+        // row 2 downward, a regular gridline in row 1
+        int boundaryX = xs[3] - controller.camera.getAbsX() + GUTTER_W;
+        int insideMergeY = ys[2] - controller.camera.getAbsY() + HEADER_H + (ys[3] - ys[2]) / 2;
+        int aboveMergeY = ys[1] - controller.camera.getAbsY() + HEADER_H + (ys[2] - ys[1]) / 2;
+
+        assertTrue(rowContainsColor(pixels, boundaryX, aboveMergeY, GRIDLINE_C),
+            "control: the same column boundary outside the merge must show a gridline");
+        assertFalse(rowContainsColor(pixels, boundaryX, insideMergeY, GRIDLINE_C),
+            "the merged block must cover the gridline between its columns");
+    }
+
+    /** Checks the three pixels around (x, y) horizontally for the given color. */
+    private boolean rowContainsColor(PixelReader pixels, int x, int y, Color color) {
+        for (int dx = -1; dx <= 1; dx++)
+            if (colorsClose(pixels.getColor(x + dx, y), color)) return true;
+        return false;
+    }
+
+    private boolean colorsClose(Color a, Color b) {
+        return Math.abs(a.getRed() - b.getRed()) < 0.05 &&
+               Math.abs(a.getGreen() - b.getGreen()) < 0.05 &&
+               Math.abs(a.getBlue() - b.getBlue()) < 0.05;
+    }
+
+    private void typeText(FxRobot robot, String s) {
+        for (char c : s.toCharArray()) {
+            if (c == ' ') robot.type(KeyCode.SPACE);
+            else if (Character.isUpperCase(c))
+                robot.press(KeyCode.SHIFT)
+                     .type(KeyCode.getKeyCode(String.valueOf(c)))
+                     .release(KeyCode.SHIFT);
+            else robot.type(KeyCode.getKeyCode(String.valueOf(Character.toUpperCase(c))));
+        }
+    }
+}

--- a/src/test/java/vimicalc/controller/UndoMergeUiTest.java
+++ b/src/test/java/vimicalc/controller/UndoMergeUiTest.java
@@ -180,7 +180,7 @@ class UndoMergeUiTest {
     }
 
     @Test
-    void unformattedMergeCoversItsInteriorGridlines(FxRobot robot) {
+    void unformattedMergeCoversInteriorGridlinesButKeepsItsBorders(FxRobot robot) {
         // Merge B2:C3 with no formatting anywhere; gridlines are on by default
         robot.type(KeyCode.V, KeyCode.L, KeyCode.J, KeyCode.M);
         // Move the cursor off the merge so its opaque highlight doesn't
@@ -206,12 +206,31 @@ class UndoMergeUiTest {
             "control: the same column boundary outside the merge must show a gridline");
         assertFalse(rowContainsColor(pixels, boundaryX, insideMergeY, GRIDLINE_C),
             "the merged block must cover the gridline between its columns");
+
+        // The block's own border must survive the covering fill (the PR #80
+        // revert): left border = column 1|2 boundary beside the merge rows,
+        // top border = row 1|2 boundary above the merge columns.
+        int leftBorderX = xs[2] - controller.camera.getAbsX() + GUTTER_W;
+        int topBorderY = ys[2] - controller.camera.getAbsY() + HEADER_H;
+        int insideMergeX = xs[2] - controller.camera.getAbsX() + GUTTER_W + (xs[3] - xs[2]) / 2;
+
+        assertTrue(rowContainsColor(pixels, leftBorderX, insideMergeY, GRIDLINE_C),
+            "the merged block's leftmost border gridline must stay visible");
+        assertTrue(colContainsColor(pixels, insideMergeX, topBorderY, GRIDLINE_C),
+            "the merged block's topmost border gridline must stay visible");
     }
 
     /** Checks the three pixels around (x, y) horizontally for the given color. */
     private boolean rowContainsColor(PixelReader pixels, int x, int y, Color color) {
         for (int dx = -1; dx <= 1; dx++)
             if (colorsClose(pixels.getColor(x + dx, y), color)) return true;
+        return false;
+    }
+
+    /** Checks the three pixels around (x, y) vertically for the given color. */
+    private boolean colContainsColor(PixelReader pixels, int x, int y, Color color) {
+        for (int dy = -1; dy <= 1; dy++)
+            if (colorsClose(pixels.getColor(x, y + dy), color)) return true;
         return false;
     }
 


### PR DESCRIPTION
## Summary

Re-lands PR #79 (the issue #77 cell-merging fixes, reverted by #80) with the rendering regression fixed: **a merged cell's topmost and leftmost border gridlines were not drawn.**

### Why the diff shows all of #79 again

Since #79's commits are already ancestors of `main` (merged, then reverted), a branch based on the old `fix/merge-bugs-issue77` head would merge as a no-op for those changes. This branch is instead `main` + revert of the revert commit (8587932) — verified tree-identical to the post-#79 merge state — plus the new fix on top. Only the last commit (d7a5c6c) is new relative to #79.

### Root cause

`Picture.drawGridlines` strokes each 1px gridline at `boundary + 0.5`, so the line occupies the pixel row/column starting *at* the boundary coordinate. #79's background fill for unformatted merge blocks started at exactly that origin pixel — `fillRect(cellX, cellY, w, h)` — painting over the block's top and left border lines (the right/bottom fill edges stop one pixel short of theirs, which is why only two sides vanished). With the fill color equal to the canvas background, the borders read as missing gridlines.

**Fix:** inset the fill by 1px on the top and left. Interior gridlines sit a full cell inside, so they remain covered.

### Why #79's test missed it

`UndoMergeUiTest`'s gridline check only asserted an *interior* boundary was covered; it never sampled the block's own border pixels. It now also asserts the top and left border pixels stay gridline-colored — confirmed the new assertions **fail** against the un-inset fill and pass with it.

## Automated verification

- Full suite green under TestFX Monocle headless (all unit + UI tests, 0 failures), including `UndoMergeUiTest` and `MergeInteractionUiTest`.
- Headless screenshot probe: merged B5:E10 (the range from the bug report), pixel-scanned the snapshot — all four border gridlines present at their boundary coordinates, all five interior gridlines covered.

## Manual tests to run

New entry **5.8** in `KeyCommandManualTests.md`, plus a re-check of the #79 entries:

1. **5.8 — Merged block keeps all four borders:** merge B5:E10 (`v`, extend, `m`), move the cursor off the block. All four border gridlines must be visible (top and left included), while gridlines *inside* the block are gone. Scroll around (`20j` / `20k`) and re-check.
2. **5.5–5.7 — the #79 compound-undo behaviors:** undo/redo of merge, unmerge, and VISUAL delete still behave as described.
3. Sanity: VISUAL-select a large formatted block (issue #77 bug 3) — no slowdown/crash.

Fixes the regression that prompted #80; re-fixes #77.

🤖 Generated with [Claude Code](https://claude.com/claude-code)