### PR TITLE
Add dot-file configuration mechanism (vimicalcrc) for startup preferences (#76)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,30 @@ The build is preconfigured with `prism.order=sw` so that JavaFX uses software re
 
 The convenience scripts `wss.sh` (Linux/macOS) and `wss.ps1` (Windows) wrap the Gradle run task.
 
+## Configuration
+
+Startup preferences are read from an optional config file — `$XDG_CONFIG_HOME/vimicalc/vimicalcrc`
+(`~/.config/vimicalc/vimicalcrc` when the variable is unset), falling back to `~/.vimicalc`.
+The file uses vimrc-style directives, one `set <key> <value>` per line; `"` starts a comment:
+
+```vim
+" VimiCalc configuration
+set macroDelay 100
+set gridlines off
+set zoom 1.5
+```
+
+| Key | Values | Default |
+|---|---|---|
+| `completionNames` | `long` / `short` | `long` |
+| `macroDelay` | `0`–`10000` ms | `0` |
+| `gridlines` | `on` / `off` | `on` |
+| `zoom` | `0.25`–`4.0` | `1.0` |
+
+Note that `zoom` takes a *factor*, unlike the `:zoom` command's percentage (`25`–`400`).
+Invalid or unknown lines are skipped with a warning (shown in the info bar and on stderr);
+a missing file simply means all defaults. The app never creates the file itself.
+
 ## Project Structure
 
 ```

--- a/src/main/java/vimicalc/Main.java
+++ b/src/main/java/vimicalc/Main.java
@@ -6,7 +6,9 @@ import javafx.scene.Parent;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
 import vimicalc.controller.Controller;
+import vimicalc.model.Settings;
 
+import java.nio.file.Path;
 import java.util.Arrays;
 
 /**
@@ -20,6 +22,15 @@ public class Main extends Application {
 
     /** The first command-line argument (file path), or {@code null} if none was provided. */
     public static String arg1 = null;
+
+    /**
+     * Startup configuration parsed from the user's {@code vimicalcrc}, or all
+     * defaults when no config file exists. Set once in {@link #main} before
+     * launch and read by {@code Controller.initialize}; like {@link #arg1},
+     * static because the {@code Controller} is instantiated by the FXML loader
+     * (UI tests that load the FXML directly bypass {@code main} and see defaults).
+     */
+    public static Settings settings = Settings.defaults();
 
     @Override
     public void start(Stage primaryStage) throws Exception {
@@ -45,6 +56,10 @@ public class Main extends Application {
     public static void main(String[] args) {
         System.out.println("args: " + Arrays.toString(args));
         if (args.length > 0) arg1 = args[0];
+        settings = Settings.loadFrom(Settings.candidatePaths(
+            System.getenv("XDG_CONFIG_HOME"),
+            Path.of(System.getProperty("user.home"))));
+        settings.getWarnings().forEach(w -> System.err.println("vimicalcrc: " + w));
         launch(args);
         System.out.println();
     }

--- a/src/main/java/vimicalc/controller/Controller.java
+++ b/src/main/java/vimicalc/controller/Controller.java
@@ -27,6 +27,7 @@ import static javafx.scene.input.KeyCode.ESCAPE;
 import static javafx.scene.input.KeyCode.N;
 import static javafx.scene.input.KeyCode.P;
 import static vimicalc.Main.arg1;
+import static vimicalc.Main.settings;
 
 /**
  * The main controller that orchestrates all user interaction with the spreadsheet.
@@ -900,14 +901,18 @@ public class Controller implements Initializable {
         helpMenu = new HelpMenu(helpLabel);
         completionPopup = new CompletionPopup(completionLabelBox, overlayPane);
         sheet = new Sheet();
-        sheet.setPositions(new Positions(
+        Positions positions = new Positions(
             CANVAS_W - GUTTER_W,
             CANVAS_H - HEADER_H,
             DEFAULT_CELL_W,
             DEFAULT_CELL_H,
             new HashMap<>(),
             new HashMap<>()
-        ));
+        );
+        positions.setGridlines(settings.gridlinesOn());
+        positions.setMacroDelayMs(settings.getMacroDelayMs());
+        positions.setZoom(settings.getZoom());
+        sheet.setPositions(positions);
         sheet.setFileIOCallbacks(new FileIOCallbacks() {
             @Override
             public void onFileSaved(String filename) {
@@ -923,6 +928,14 @@ public class Controller implements Initializable {
         });
         macros = new HashMap<>();
         reset();
+        // Config warnings go up before the arg1 block: the InfoBar is a single
+        // line (last-write-wins), and a file-load error is the more urgent
+        // message. The full warning list is always on stderr from Main.
+        if (!settings.getWarnings().isEmpty()) {
+            infoBar.setInfobarTxt(settings.getWarnings().size() == 1
+                ? "vimicalcrc: " + settings.getWarnings().get(0)
+                : "vimicalcrc: " + settings.getWarnings().size() + " warnings (see stderr)");
+        }
         if (arg1 != null) {
             try {
                 sheet.readFile(arg1);

--- a/src/main/java/vimicalc/model/Settings.java
+++ b/src/main/java/vimicalc/model/Settings.java
@@ -1,0 +1,240 @@
+package vimicalc.model;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static vimicalc.view.Defaults.DEFAULT_GRIDLINES;
+import static vimicalc.view.Defaults.DEFAULT_MACRO_DELAY_MS;
+import static vimicalc.view.Defaults.DEFAULT_ZOOM;
+import static vimicalc.view.Defaults.MAX_MACRO_DELAY_MS;
+import static vimicalc.view.Defaults.MAX_ZOOM;
+import static vimicalc.view.Defaults.MIN_ZOOM;
+
+/**
+ * Persistent user preferences read once at startup from an optional dot-file
+ * (issue #76). JavaFX-free; the only file I/O is {@link #loadFrom(List)},
+ * called solely from {@code Main} — everything else is a pure function of its
+ * input.
+ *
+ * <p><b>File location</b> (first existing candidate wins, see
+ * {@link #candidatePaths(String, Path)}):</p>
+ * <ol>
+ *   <li>{@code $XDG_CONFIG_HOME/vimicalc/vimicalcrc}
+ *       ({@code ~/.config/vimicalc/vimicalcrc} when the variable is unset)</li>
+ *   <li>{@code ~/.vimicalc}</li>
+ * </ol>
+ * <p>The application never creates either file; absence simply means all
+ * defaults.</p>
+ *
+ * <p><b>Format</b> — vimrc-style directives, one per line:</p>
+ * <pre>
+ * " VimiCalc configuration
+ * set macroDelay 100
+ * set gridlines off
+ * </pre>
+ * <p>{@code "} starts a comment (to end of line); blank lines are ignored.
+ * Keys are the canonical camelCase names used by the colon-commands.</p>
+ *
+ * <p><b>Keys</b>:</p>
+ * <table>
+ *   <caption>Supported settings</caption>
+ *   <tr><th>Key</th><th>Values</th><th>Default</th></tr>
+ *   <tr><td>{@code completionNames}</td><td>{@code long} / {@code short}</td><td>{@code long}</td></tr>
+ *   <tr><td>{@code macroDelay}</td><td>{@code 0}–{@code 10000} ms</td><td>{@code 0}</td></tr>
+ *   <tr><td>{@code gridlines}</td><td>{@code on} / {@code off}</td><td>{@code on}</td></tr>
+ *   <tr><td>{@code zoom}</td><td>{@code 0.25}–{@code 4.0}</td><td>{@code 1.0}</td></tr>
+ * </table>
+ *
+ * <p>Note that {@code zoom} is a <em>factor</em>, unlike the {@code :zoom}
+ * colon-command which takes a percentage ({@code 25}–{@code 400}).</p>
+ *
+ * <p><b>Error policy</b>: parsing never throws and never aborts startup.
+ * Malformed lines, unknown keys, and invalid or out-of-range values are
+ * skipped with a warning (collected in {@link #getWarnings()}), keeping the
+ * default for that key — matching the reject-don't-clamp behavior of the
+ * corresponding colon-commands. Unknown keys are tolerated so a config
+ * written for a newer version doesn't break an older one.</p>
+ */
+public final class Settings {
+
+    /**
+     * Which command-name style completion suggests: full canonical names
+     * ({@code LONG}) or short aliases ({@code SHORT}). Parsed and stored for
+     * issue #72, which will wire it into command completion; it has no
+     * consumer yet.
+     */
+    public enum CompletionNames { LONG, SHORT }
+
+    /** Completion-name style suggested by command completion. */
+    private CompletionNames completionNames = CompletionNames.LONG;
+    /** Startup value for {@link vimicalc.view.Positions#setMacroDelayMs(int)}. */
+    private int macroDelayMs = DEFAULT_MACRO_DELAY_MS;
+    /** Startup value for {@link vimicalc.view.Positions#setGridlines(boolean)}. */
+    private boolean gridlines = DEFAULT_GRIDLINES;
+    /** Startup value for {@link vimicalc.view.Positions#setZoom(double)}. */
+    private double zoom = DEFAULT_ZOOM;
+    /** Human-readable warnings accumulated while loading and parsing. */
+    private final List<String> warnings = new ArrayList<>();
+
+    private Settings() {} // construct via defaults(), parse(), or loadFrom()
+
+    /** @return settings with every key at its default and no warnings */
+    public static Settings defaults() {
+        return new Settings();
+    }
+
+    /**
+     * Parses config-file content into a {@link Settings}. Pure function of its
+     * input: no I/O, never throws. Invalid lines are skipped with a warning
+     * (see the class Javadoc for the error policy); duplicate keys keep the
+     * last occurrence.
+     *
+     * @param lines the file content, one entry per line
+     * @return the parsed settings, with any warnings recorded
+     */
+    public static Settings parse(List<String> lines) {
+        Settings settings = new Settings();
+        for (int i = 0; i < lines.size(); i++) {
+            String line = lines.get(i);
+            int comment = line.indexOf('"');
+            if (comment >= 0) line = line.substring(0, comment);
+            line = line.trim();
+            if (line.isEmpty()) continue;
+
+            String[] tokens = line.split("\\s+");
+            if (tokens.length != 3 || !tokens[0].equals("set")) {
+                settings.warnings.add("line " + (i + 1) + ": expected 'set <key> <value>'");
+                continue;
+            }
+            settings.applyDirective(i + 1, tokens[1], tokens[2]);
+        }
+        return settings;
+    }
+
+    /**
+     * Applies a single {@code set <key> <value>} directive, recording a
+     * warning and keeping the current value when the key or value is invalid.
+     *
+     * @param lineNo 1-based line number, for warning messages
+     * @param key    the setting name (canonical camelCase)
+     * @param value  the unparsed value token
+     */
+    private void applyDirective(int lineNo, String key, String value) {
+        switch (key) {
+            case "completionNames" -> {
+                if (value.equals("long")) completionNames = CompletionNames.LONG;
+                else if (value.equals("short")) completionNames = CompletionNames.SHORT;
+                else warnings.add("line " + lineNo + ": completionNames expects long or short.");
+            }
+            case "macroDelay" -> {
+                Integer ms = parseInt(value);
+                if (ms == null || ms < 0 || ms > MAX_MACRO_DELAY_MS)
+                    warnings.add("line " + lineNo + ": macroDelay expects a delay between 0 and "
+                                 + MAX_MACRO_DELAY_MS + " ms.");
+                else macroDelayMs = ms;
+            }
+            case "gridlines" -> {
+                if (value.equals("on")) gridlines = true;
+                else if (value.equals("off")) gridlines = false;
+                else warnings.add("line " + lineNo + ": gridlines expects on or off.");
+            }
+            case "zoom" -> {
+                Double factor = parseDouble(value);
+                if (factor == null || factor < MIN_ZOOM || factor > MAX_ZOOM)
+                    warnings.add("line " + lineNo + ": zoom expects a factor between "
+                                 + MIN_ZOOM + " and " + MAX_ZOOM + ".");
+                else zoom = factor;
+            }
+            default -> warnings.add("line " + lineNo + ": unknown key '" + key + "'");
+        }
+    }
+
+    /** @return the parsed int, or {@code null} if the token is not an integer */
+    private static Integer parseInt(String token) {
+        try {
+            return Integer.parseInt(token);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    /** @return the parsed double, or {@code null} if the token is not a number */
+    private static Double parseDouble(String token) {
+        try {
+            return Double.parseDouble(token);
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    /**
+     * Resolves the candidate config-file paths in priority order. Pure
+     * function so path resolution is testable without touching the real
+     * environment; {@code Main} supplies the live values.
+     *
+     * @param xdgConfigHome the {@code XDG_CONFIG_HOME} value; {@code null} or
+     *                      blank means unset (falls back to {@code home/.config})
+     * @param home          the user's home directory
+     * @return {@code [<config dir>/vimicalc/vimicalcrc, home/.vimicalc]}
+     */
+    public static List<Path> candidatePaths(String xdgConfigHome, Path home) {
+        Path configDir = (xdgConfigHome == null || xdgConfigHome.isBlank())
+                         ? home.resolve(".config")
+                         : Path.of(xdgConfigHome);
+        return List.of(configDir.resolve("vimicalc").resolve("vimicalcrc"),
+                       home.resolve(".vimicalc"));
+    }
+
+    /**
+     * Reads and parses the first existing candidate file. The only I/O in
+     * this class; called solely from {@code Main}. Never creates a file and
+     * never throws: no candidate existing yields silent defaults, and an
+     * unreadable file yields defaults plus a warning.
+     *
+     * @param candidates config-file paths in priority order,
+     *                   from {@link #candidatePaths(String, Path)}
+     * @return the loaded settings, or defaults when no file exists
+     */
+    public static Settings loadFrom(List<Path> candidates) {
+        for (Path candidate : candidates) {
+            if (!Files.exists(candidate)) continue;
+            try {
+                return parse(Files.readAllLines(candidate));
+            } catch (IOException e) {
+                Settings settings = new Settings();
+                settings.warnings.add("could not read " + candidate + ": " + e.getMessage());
+                return settings;
+            }
+        }
+        return new Settings();
+    }
+
+    /** @return the completion-name style (stored for issue #72; unconsumed for now) */
+    public CompletionNames getCompletionNames() {
+        return completionNames;
+    }
+
+    /** @return the startup delay between replayed macro keystrokes, in milliseconds */
+    public int getMacroDelayMs() {
+        return macroDelayMs;
+    }
+
+    /** @return whether cell gridlines are drawn at startup */
+    public boolean gridlinesOn() {
+        return gridlines;
+    }
+
+    /** @return the startup view zoom factor */
+    public double getZoom() {
+        return zoom;
+    }
+
+    /** @return the warnings accumulated while loading and parsing, unmodifiable */
+    public List<String> getWarnings() {
+        return Collections.unmodifiableList(warnings);
+    }
+}

--- a/src/main/java/vimicalc/view/Defaults.java
+++ b/src/main/java/vimicalc/view/Defaults.java
@@ -38,6 +38,8 @@ public final class Defaults {
     public static final int DEFAULT_MACRO_DELAY_MS = 0;
     /** Maximum delay accepted by {@code :macroDelay}, in milliseconds. */
     public static final int MAX_MACRO_DELAY_MS = 10_000;
+    /** Default cell gridline visibility. */
+    public static final boolean DEFAULT_GRIDLINES = true;
     /** Default cell background color. */
     public static final Color DEFAULT_CELL_C = Color.WHITE;
     /** Default cell text color. */

--- a/src/main/java/vimicalc/view/Positions.java
+++ b/src/main/java/vimicalc/view/Positions.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 
+import static vimicalc.view.Defaults.DEFAULT_GRIDLINES;
 import static vimicalc.view.Defaults.DEFAULT_MACRO_DELAY_MS;
 import static vimicalc.view.Defaults.DEFAULT_ZOOM;
 import static vimicalc.view.Defaults.MAX_ZOOM;
@@ -35,18 +36,22 @@ public class Positions {
     private int[] cellAbsXs, cellAbsYs;
     /**
      * The view zoom factor multiplied into every cell size during
-     * {@link #generate(int, int)}. Session-only view state — never persisted.
+     * {@link #generate(int, int)}. Session-only view state — never persisted
+     * with the spreadsheet, though a startup value may come from the user's
+     * {@code vimicalcrc} (see {@link vimicalc.model.Settings}).
      */
     private double zoom = DEFAULT_ZOOM;
     /**
      * Whether cell gridlines are drawn, toggled by the {@code :gridlines}
-     * command. Session-only view state — never persisted.
+     * command. Session-only view state — never persisted with the spreadsheet,
+     * though a startup value may come from the user's {@code vimicalcrc}.
      */
-    private boolean gridlines = true;
+    private boolean gridlines = DEFAULT_GRIDLINES;
     /**
      * Milliseconds between replayed keystrokes during {@code @x} macro playback,
      * set by the {@code :macroDelay} command. 0 replays instantly (synchronously,
-     * the historical behavior). Session-only state — never persisted.
+     * the historical behavior). Session-only state — never persisted with the
+     * spreadsheet, though a startup value may come from the user's {@code vimicalcrc}.
      */
     private int macroDelayMs = DEFAULT_MACRO_DELAY_MS;
 
@@ -224,6 +229,17 @@ public class Positions {
      */
     public void toggleGridlines() {
         gridlines = !gridlines;
+    }
+
+    /**
+     * Sets gridline visibility absolutely (used for startup configuration).
+     * Like {@link #toggleGridlines()} this needs no {@code regenerate()} —
+     * layout is unaffected, only what gets drawn.
+     *
+     * @param gridlines whether cell gridlines are drawn
+     */
+    public void setGridlines(boolean gridlines) {
+        this.gridlines = gridlines;
     }
 
     /** @return the delay between replayed macro keystrokes, in milliseconds (0 = instant) */

--- a/src/test/java/vimicalc/model/SettingsTest.java
+++ b/src/test/java/vimicalc/model/SettingsTest.java
@@ -1,0 +1,278 @@
+package vimicalc.model;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static vimicalc.model.Settings.CompletionNames.LONG;
+import static vimicalc.model.Settings.CompletionNames.SHORT;
+
+/**
+ * Unit tests for {@link Settings}: the {@code vimicalcrc} parser, the
+ * candidate-path resolution, and file loading (issue #76).
+ */
+class SettingsTest {
+
+    /** Parses the given lines, asserting no warnings were produced. */
+    private static Settings parseClean(String... lines) {
+        Settings settings = Settings.parse(List.of(lines));
+        assertEquals(List.of(), settings.getWarnings());
+        return settings;
+    }
+
+    // ── Defaults ──
+
+    @Nested
+    class DefaultsTests {
+
+        @Test
+        void defaultsFactoryYieldsAllDefaults() {
+            Settings settings = Settings.defaults();
+            assertEquals(LONG, settings.getCompletionNames());
+            assertEquals(0, settings.getMacroDelayMs());
+            assertTrue(settings.gridlinesOn());
+            assertEquals(1.0, settings.getZoom());
+            assertEquals(List.of(), settings.getWarnings());
+        }
+
+        @Test
+        void emptyContentYieldsAllDefaults() {
+            Settings settings = parseClean();
+            assertEquals(LONG, settings.getCompletionNames());
+            assertEquals(0, settings.getMacroDelayMs());
+            assertTrue(settings.gridlinesOn());
+            assertEquals(1.0, settings.getZoom());
+        }
+    }
+
+    // ── Grammar ──
+
+    @Nested
+    class GrammarTests {
+
+        @Test
+        void blankAndWhitespaceLinesAreIgnored() {
+            parseClean("", "   ", "\t");
+        }
+
+        @Test
+        void fullLineCommentsAreIgnored() {
+            parseClean("\" VimiCalc configuration", "  \" indented comment");
+        }
+
+        @Test
+        void trailingCommentsAreStripped() {
+            Settings settings = parseClean("set gridlines off \" hide the grid");
+            assertFalse(settings.gridlinesOn());
+        }
+
+        @Test
+        void missingValueWarnsWithLineNumber() {
+            Settings settings = Settings.parse(List.of("set macroDelay"));
+            assertEquals(List.of("line 1: expected 'set <key> <value>'"), settings.getWarnings());
+        }
+
+        @Test
+        void extraTokensWarn() {
+            Settings settings = Settings.parse(List.of("set macroDelay 100 200"));
+            assertEquals(1, settings.getWarnings().size());
+            assertEquals(0, settings.getMacroDelayMs());
+        }
+
+        @Test
+        void nonSetDirectiveWarns() {
+            Settings settings = Settings.parse(List.of("let zoom 2.0"));
+            assertEquals(List.of("line 1: expected 'set <key> <value>'"), settings.getWarnings());
+        }
+
+        @Test
+        void parsingContinuesPastBadLines() {
+            Settings settings = Settings.parse(List.of("nonsense", "set zoom 2.0"));
+            assertEquals(1, settings.getWarnings().size());
+            assertEquals(2.0, settings.getZoom());
+        }
+
+        @Test
+        void warningsReportOneBasedLineNumbers() {
+            Settings settings = Settings.parse(List.of("set zoom 2.0", "", "bad line"));
+            assertEquals(List.of("line 3: expected 'set <key> <value>'"), settings.getWarnings());
+        }
+    }
+
+    // ── Keys: valid values ──
+
+    @Nested
+    class KeyTests {
+
+        @Test
+        void completionNamesLongAndShort() {
+            assertEquals(LONG, parseClean("set completionNames long").getCompletionNames());
+            assertEquals(SHORT, parseClean("set completionNames short").getCompletionNames());
+        }
+
+        @Test
+        void macroDelayAcceptsBounds() {
+            assertEquals(0, parseClean("set macroDelay 0").getMacroDelayMs());
+            assertEquals(10000, parseClean("set macroDelay 10000").getMacroDelayMs());
+            assertEquals(100, parseClean("set macroDelay 100").getMacroDelayMs());
+        }
+
+        @Test
+        void gridlinesOnAndOff() {
+            assertTrue(parseClean("set gridlines on").gridlinesOn());
+            assertFalse(parseClean("set gridlines off").gridlinesOn());
+        }
+
+        @Test
+        void zoomAcceptsBounds() {
+            assertEquals(0.25, parseClean("set zoom 0.25").getZoom());
+            assertEquals(4.0, parseClean("set zoom 4.0").getZoom());
+            assertEquals(1.5, parseClean("set zoom 1.5").getZoom());
+        }
+
+        @Test
+        void duplicateKeyKeepsTheLastValueSilently() {
+            Settings settings = parseClean("set macroDelay 100", "set macroDelay 200");
+            assertEquals(200, settings.getMacroDelayMs());
+        }
+    }
+
+    // ── Keys: invalid values fall back to defaults (no clamping) ──
+
+    @Nested
+    class RejectionTests {
+
+        /** Asserts the line produces exactly one warning and leaves all defaults. */
+        private Settings assertRejected(String line) {
+            Settings settings = Settings.parse(List.of(line));
+            assertEquals(1, settings.getWarnings().size(), "expected one warning for: " + line);
+            assertEquals(LONG, settings.getCompletionNames());
+            assertEquals(0, settings.getMacroDelayMs());
+            assertTrue(settings.gridlinesOn());
+            assertEquals(1.0, settings.getZoom());
+            return settings;
+        }
+
+        @Test
+        void completionNamesRejectsUnknownStyle() {
+            assertRejected("set completionNames medium");
+        }
+
+        @Test
+        void macroDelayRejectsNonInteger() {
+            assertRejected("set macroDelay fast");
+            assertRejected("set macroDelay 1.5");
+        }
+
+        @Test
+        void macroDelayRejectsOutOfRange() {
+            assertRejected("set macroDelay -1");
+            assertRejected("set macroDelay 10001");
+        }
+
+        @Test
+        void gridlinesRejectsNonToggleWord() {
+            assertRejected("set gridlines true");
+        }
+
+        @Test
+        void zoomRejectsNonNumeric() {
+            assertRejected("set zoom big");
+        }
+
+        @Test
+        void zoomRejectsOutOfRangeWithoutClamping() {
+            // 150 is a valid :zoom percentage but not a valid config factor;
+            // it must fall back to 1.0, not clamp to 4.0.
+            Settings settings = assertRejected("set zoom 150");
+            assertTrue(settings.getWarnings().get(0).contains("factor"));
+            assertRejected("set zoom 0.1");
+        }
+
+        @Test
+        void unknownKeyWarnsAndParsingContinues() {
+            Settings settings = Settings.parse(List.of("set theme dark", "set zoom 2.0"));
+            assertEquals(List.of("line 1: unknown key 'theme'"), settings.getWarnings());
+            assertEquals(2.0, settings.getZoom());
+        }
+    }
+
+    // ── Candidate-path resolution ──
+
+    @Nested
+    class PathTests {
+
+        private final Path home = Path.of("/home/someone");
+
+        @Test
+        void xdgConfigHomeTakesPriority() {
+            List<Path> candidates = Settings.candidatePaths("/custom/xdg", home);
+            assertEquals(Path.of("/custom/xdg/vimicalc/vimicalcrc"), candidates.get(0));
+        }
+
+        @Test
+        void unsetXdgConfigHomeFallsBackToDotConfig() {
+            assertEquals(home.resolve(".config/vimicalc/vimicalcrc"),
+                         Settings.candidatePaths(null, home).get(0));
+            assertEquals(home.resolve(".config/vimicalc/vimicalcrc"),
+                         Settings.candidatePaths("  ", home).get(0));
+        }
+
+        @Test
+        void homeDotFileIsAlwaysTheSecondCandidate() {
+            assertEquals(home.resolve(".vimicalc"),
+                         Settings.candidatePaths("/custom/xdg", home).get(1));
+            assertEquals(home.resolve(".vimicalc"),
+                         Settings.candidatePaths(null, home).get(1));
+        }
+    }
+
+    // ── File loading ──
+
+    @Nested
+    class LoadingTests {
+
+        @TempDir
+        Path tempDir;
+
+        private Path xdgFile;
+        private Path fallbackFile;
+
+        private List<Path> candidates() {
+            xdgFile = tempDir.resolve("xdg/vimicalc/vimicalcrc");
+            fallbackFile = tempDir.resolve(".vimicalc");
+            return List.of(xdgFile, fallbackFile);
+        }
+
+        @Test
+        void firstExistingCandidateWins() throws Exception {
+            List<Path> candidates = candidates();
+            Files.createDirectories(xdgFile.getParent());
+            Files.write(xdgFile, List.of("set zoom 2.0"));
+            Files.write(fallbackFile, List.of("set zoom 3.0"));
+            assertEquals(2.0, Settings.loadFrom(candidates).getZoom());
+        }
+
+        @Test
+        void fallbackIsUsedWhenXdgFileIsAbsent() throws Exception {
+            List<Path> candidates = candidates();
+            Files.write(fallbackFile, List.of("set gridlines off"));
+            assertFalse(Settings.loadFrom(candidates).gridlinesOn());
+        }
+
+        @Test
+        void noFileYieldsSilentDefaultsAndCreatesNothing() {
+            List<Path> candidates = candidates();
+            Settings settings = Settings.loadFrom(candidates);
+            assertEquals(1.0, settings.getZoom());
+            assertEquals(List.of(), settings.getWarnings());
+            assertTrue(Files.notExists(xdgFile));
+            assertTrue(Files.notExists(fallbackFile));
+        }
+    }
+}

--- a/src/test/java/vimicalc/view/PositionsTest.java
+++ b/src/test/java/vimicalc/view/PositionsTest.java
@@ -172,4 +172,20 @@ class PositionsTest {
         assertEquals(firstXC, positions.getFirstXC());
         assertEquals(lastXC, positions.getLastXC());
     }
+
+    @Test
+    void setGridlinesIsAbsoluteAndComposesWithToggle() {
+        assertTrue(positions.gridlinesOn());
+
+        positions.setGridlines(false);
+        assertFalse(positions.gridlinesOn());
+        positions.setGridlines(false);
+        assertFalse(positions.gridlinesOn());
+
+        positions.toggleGridlines();
+        assertTrue(positions.gridlinesOn());
+
+        positions.setGridlines(true);
+        assertTrue(positions.gridlinesOn());
+    }
 }


### PR DESCRIPTION
Implements #76: an optional config file read once at startup, giving `:gridlines`, `:macroDelay`, and zoom (and future settings) persistence across launches. Closes #76.

## What

- **File location**: `$XDG_CONFIG_HOME/vimicalc/vimicalcrc` (`~/.config/vimicalc/vimicalcrc` when unset), falling back to `~/.vimicalc` only if the XDG file doesn't exist. The app never creates either file; absence means all defaults.
- **Format**: vimrc-style `set <key> <value>` lines; `"` starts a comment; blank lines ignored. Keys are the canonical camelCase names.

| Key | Values | Default |
|---|---|---|
| `completionNames` | `long` / `short` | `long` |
| `macroDelay` | `0`–`10000` ms | `0` |
| `gridlines` | `on` / `off` | `on` |
| `zoom` | `0.25`–`4.0` | `1.0` |

## Design

- **`model/Settings`** (new, JavaFX-free): pure `parse` and `candidatePaths` functions; `loadFrom` is the only file I/O and is called solely from `Main` — mirroring the `FileIOCallbacks` boundary discipline. Referenced `Defaults` constants are compile-time primitives, so headless model tests never load JavaFX (same precedent as `CommandRegistry`).
- **Error policy**: never aborts startup. Malformed lines / unknown keys / invalid or out-of-range values warn and keep the default — *reject-don't-clamp*, matching `:zoom` and `:macroDelay`. Warnings go to stderr in full; the InfoBar shows a single warning verbatim or an `N warnings (see stderr)` summary (a later file-load error may overwrite it deliberately — the InfoBar is single-line).
- **Wiring**: `Main` builds `Settings` before `launch` into a static field (the established `Main.arg1` pattern — `Controller` is FXMLLoader-instantiated, so constructor injection isn't possible). `Controller.initialize` applies it to `Positions` via a new absolute `setGridlines` plus the existing setters.
- **`zoom` is a factor** (0.25–4.0) per the issue, unlike `:zoom`'s percentage (25–400); `set zoom 150` is rejected with a warning that says "factor" rather than silently meaning 150×.
- **`completionNames` is parsed and stored but has no consumer yet** — #72 (sub-issue, agreed first consumer) will wire it into command completion; noted in its Javadoc.
- Per the issue's suggested scope: read-only at startup, no `:set` colon-command yet.

## Testing

- `SettingsTest` (28 cases, headless): defaults, grammar (comments, blank lines, malformed lines with 1-based line numbers, parsing continues past bad lines), per-key boundary values, fallback-not-clamp rejection (incl. the `zoom 150` → `1.0` percent-confusion regression), unknown-key tolerance, duplicate-key last-wins, `candidatePaths` XDG set/unset/blank, and `@TempDir` loading (XDG priority, fallback, absent-file silence + nothing created).
- `PositionsTest`: new `setGridlines` coverage.
- Filtered headless suite (per AGENTS.md) passes on Fedora/Wayland.
- End-to-end (headless Monocle probe against the real FXML UI): launched with a scratch `XDG_CONFIG_HOME` containing `zoom 2.0`, `gridlines off`, and one bad `macroDelay` line — screenshot confirmed 2× cells, no gridlines, and the warning in the InfoBar (screenshot in the session; steps reproducible via the repo verify skill).


## Manual test plan (please verify by hand)

1. `mkdir -p ~/.config/vimicalc` and create `~/.config/vimicalc/vimicalcrc`:
   ```vim
   " test config
   set zoom 1.5
   set gridlines off
   set macroDelay 200
   ```
   `./gradlew run` → grid starts at 150% with no gridlines; `:gridlines` still toggles them back on; record and replay a macro → visibly paced.
2. Add a bad line (`set zoom 150`) → on launch the InfoBar shows the factor warning and zoom stays 100%; stderr shows the same.
3. Rename the file away, create `~/.vimicalc` with `set gridlines off` → fallback applies. Restore both away → default launch, no messages.
4. `./gradlew run --args="somefile.json"` with a bad config → the file-load message wins the InfoBar (expected; warnings remain on stderr).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X37ChJdxDjdE1ruHVogqUJ
